### PR TITLE
fix(Argument): Fix Version switch

### DIFF
--- a/src/ir/argument.cc
+++ b/src/ir/argument.cc
@@ -63,7 +63,7 @@ NAN_METHOD(ArgumentWrapper::New) {
         argNo = Nan::To<uint32_t>(info[3]).FromJust();
     }
 
-#if __clang_major__ == 4
+#if LLVM_VERSION_MAJOR == 4
     auto* argument = new llvm::Argument { type, name, function };
 #else
     auto* argument = new llvm::Argument { type, name, function, argNo };
@@ -113,13 +113,12 @@ NAN_METHOD(ArgumentWrapper::addDereferenceableAttr) {
     llvm::AttrBuilder builder {};
     builder.addDereferenceableAttr(bytes);
 
-#if __clang_major__ == 4
+#if LLVM_VERSION_MAJOR == 4
     auto attributes = llvm::AttributeSet::get(argument->getContext(), argument->getArgNo() + 1, builder);
     argument->addAttr(attributes);
 #else
     argument->addAttrs(builder);
 #endif
-
 }
 
 llvm::Argument *ArgumentWrapper::getArgument() {


### PR DESCRIPTION
Do use the LLVM_VERSION_MAJOR variable instead of __clang_major__. The latter
is incorrect if the project is build with a clang version different
than the linked llvm version

fixes #14 