### PR TITLE
fix(Value): Fix release implementation for LLVM 5

### DIFF
--- a/llvm-node.d.ts
+++ b/llvm-node.d.ts
@@ -112,6 +112,7 @@ declare namespace llvm {
          * Deletes the value. It is, therefore, forbidden to use the value any further
          */
         release(): void;
+        deleteValue(): void;
 
         replaceAllUsesWith(value: Value): void;
         useEmpty(): boolean;

--- a/src/ir/value.cc
+++ b/src/ir/value.cc
@@ -31,7 +31,8 @@ Nan::Persistent<v8::FunctionTemplate>& ValueWrapper::valueTemplate() {
         Nan::SetAccessor(localTemplate->InstanceTemplate(), Nan::New("type").ToLocalChecked(), ValueWrapper::getType);
         Nan::SetAccessor(localTemplate->InstanceTemplate(), Nan::New("name").ToLocalChecked(), ValueWrapper::getName,
                          ValueWrapper::setName);
-        Nan::SetPrototypeMethod(localTemplate, "release", BasicBlockWrapper::release);
+        Nan::SetPrototypeMethod(localTemplate, "release", BasicBlockWrapper::deleteValue);
+        Nan::SetPrototypeMethod(localTemplate, "deleteValue", BasicBlockWrapper::deleteValue);
         Nan::SetPrototypeMethod(localTemplate, "replaceAllUsesWith", BasicBlockWrapper::replaceAllUsesWith);
         Nan::SetPrototypeMethod(localTemplate, "useEmpty", BasicBlockWrapper::useEmpty);
 
@@ -93,9 +94,13 @@ NAN_SETTER(ValueWrapper::setName) {
     ValueWrapper::FromValue(info.Holder())->value->setName(ToString(name));
 }
 
-NAN_METHOD(ValueWrapper::release) {
+NAN_METHOD(ValueWrapper::deleteValue) {
     auto* wrapper = ValueWrapper::FromValue(info.Holder());
+#if LLVM_VERSION_MAJOR == 4
     delete wrapper->getValue();
+#else
+    wrapper->getValue()->deleteValue();
+#endif
 }
 
 NAN_METHOD(ValueWrapper::replaceAllUsesWith) {

--- a/src/ir/value.h
+++ b/src/ir/value.h
@@ -33,7 +33,7 @@ private:
     static NAN_METHOD(hasName);
     static NAN_GETTER(getName);
     static NAN_SETTER(setName);
-    static NAN_METHOD(release);
+    static NAN_METHOD(deleteValue);
     static NAN_METHOD(replaceAllUsesWith);
     static NAN_METHOD(useEmpty);
 };


### PR DESCRIPTION
Use deleteValue method instead of the delete operator that is no longer
public in LLVM 5