### PR TITLE
Drop Node 4 and 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,9 @@ language: node_js
 
 node_js:
 - node
+- '8'
 - '7'
 - '6'
-- '5'
-- '4'
 
 cache: yarn
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "main": "index.js",
   "typings": "./llvm-node.d.ts",
   "engines": {
-    "node": ">=4.0"
+    "node": ">=6.0"
   },
   "engineStrict": true,
   "devDependencies": {


### PR DESCRIPTION
Latest LTS versions are not 6 an 8. Furthermore, Jest no longer supports Node < 6. So we do not either.