### PR TITLE
Add ConstantExpr class

### DIFF
--- a/llvm-node.d.ts
+++ b/llvm-node.d.ts
@@ -173,6 +173,12 @@ declare namespace llvm {
     isAllOnesValue(): boolean;
   }
 
+  class ConstantExpr extends Constant {
+    static getOr(constant1: Constant, constant2: Constant): ConstantExpr
+    static getPointerBitCastOrAddrSpaceCast(constant: Constant, type: Type): ConstantExpr
+    static getPointerCast(constant: Constant, type: Type): ConstantExpr
+  }
+
   class ConstantFP extends Constant {
     static get(context: LLVMContext, value: number): ConstantFP;
 

--- a/llvm-node.d.ts
+++ b/llvm-node.d.ts
@@ -174,8 +174,12 @@ declare namespace llvm {
   }
 
   class ConstantExpr extends Constant {
+    static getBitCast(constant: Constant, type: Type): ConstantExpr
+
     static getOr(constant1: Constant, constant2: Constant): ConstantExpr
+
     static getPointerBitCastOrAddrSpaceCast(constant: Constant, type: Type): ConstantExpr
+
     static getPointerCast(constant: Constant, type: Type): ConstantExpr
   }
 

--- a/src/ir/constant-expr.cc
+++ b/src/ir/constant-expr.cc
@@ -38,6 +38,7 @@ Nan::Persistent<v8::FunctionTemplate>& ConstantExprWrapper::constantExprTemplate
         Nan::SetMethod(localTemplate, "getPointerCast", ConstantExprWrapper::getPointerCast);
         Nan::SetMethod(localTemplate, "getIntegerCast", ConstantExprWrapper::getIntegerCast);
         Nan::SetMethod(localTemplate, "getFPCast", ConstantExprWrapper::getFPCast);
+        Nan::SetMethod(localTemplate, "getBitCast", ConstantExprWrapper::getBitCast);
 
         functionTemplate.Reset(localTemplate);
     }
@@ -92,6 +93,19 @@ NAN_METHOD(ConstantExprWrapper::getFPCast) {
     auto type = TypeWrapper::FromValue(info[1])->getType();
 
     auto constantCast = llvm::ConstantExpr::getFPCast(constant, type);
+
+    info.GetReturnValue().Set(ConstantWrapper::of(constantCast));
+}
+
+NAN_METHOD(ConstantExprWrapper::getBitCast) {
+    if (info.Length() != 2 || !ConstantWrapper::isInstance(info[0]) || !TypeWrapper::isInstance(info[1])) {
+        return Nan::ThrowTypeError("getBitCast needs to be called with: constant: Constant, type: Type");
+    }
+
+    auto constant = ConstantWrapper::FromValue(info[0])->getConstant();
+    auto type = TypeWrapper::FromValue(info[1])->getType();
+
+    auto constantCast = llvm::ConstantExpr::getBitCast(constant, type);
 
     info.GetReturnValue().Set(ConstantWrapper::of(constantCast));
 }

--- a/src/ir/constant-expr.cc
+++ b/src/ir/constant-expr.cc
@@ -1,0 +1,99 @@
+#include "constant-expr.h"
+#include "type.h"
+
+
+NAN_MODULE_INIT(ConstantExprWrapper::Init) {
+    auto constantExpr = Nan::GetFunction(Nan::New(constantExprTemplate())).ToLocalChecked();
+
+    Nan::Set(target, Nan::New("ConstantExpr").ToLocalChecked(), constantExpr);
+}
+
+v8::Local<v8::Object> ConstantExprWrapper::of(llvm::ConstantExpr* constantExpr) {
+    auto constructor = Nan::GetFunction(Nan::New(constantExprTemplate())).ToLocalChecked();
+    v8::Local<v8::Value> args[1] = { Nan::New<v8::External> (constantExpr) };
+
+    auto instance = Nan::NewInstance(constructor, 1, args).ToLocalChecked();
+
+    Nan::EscapableHandleScope escapableHandleScope {};
+    return escapableHandleScope.Escape(instance);
+}
+
+llvm::ConstantExpr* ConstantExprWrapper::getConstantExpr() {
+    return static_cast<llvm::ConstantExpr*>(getValue());
+}
+
+Nan::Persistent<v8::FunctionTemplate>& ConstantExprWrapper::constantExprTemplate() {
+    static Nan::Persistent<v8::FunctionTemplate> functionTemplate {};
+
+    if (functionTemplate.IsEmpty()) {
+        v8::Local<v8::FunctionTemplate> localTemplate = Nan::New<v8::FunctionTemplate>(ConstantExprWrapper::New);
+        localTemplate->SetClassName(Nan::New("ConstantExpr").ToLocalChecked());
+        localTemplate->InstanceTemplate()->SetInternalFieldCount(1);
+        localTemplate->Inherit(Nan::New(constantTemplate()));
+
+        Nan::SetMethod(localTemplate, "getOr", ConstantExprWrapper::getOr);
+        Nan::SetMethod(localTemplate, "getPointerBitCastOrAddrSpaceCast", ConstantExprWrapper::getPointerBitCastOrAddrSpaceCast);
+        Nan::SetMethod(localTemplate, "getPointerCast", ConstantExprWrapper::getPointerCast);
+
+        functionTemplate.Reset(localTemplate);
+    }
+
+    return functionTemplate;
+}
+
+NAN_METHOD(ConstantExprWrapper::New) {
+    if (!info.IsConstructCall()) {
+        return Nan::ThrowTypeError("ConstantExpr constructor needs to be called with new");
+    }
+
+    if (!info[0]->IsExternal()) {
+        return Nan::ThrowTypeError("ConstantExpr constructor needs to be called with: constantExpr: External");
+    }
+
+    auto* constantExpr = static_cast<llvm::ConstantExpr*>(v8::External::Cast(*info[0])->Value());
+    auto* wrapper = new ConstantExprWrapper { constantExpr };
+    wrapper->Wrap(info.This());
+
+    info.GetReturnValue().Set(info.This());
+}
+
+NAN_METHOD(ConstantExprWrapper::getOr) {
+    if (info.Length() != 2 || !ConstantWrapper::isInstance(info[0]) || !ConstantWrapper::isInstance(info[1])) {
+        return Nan::ThrowTypeError("getOr needs to be called with: constant1: Constant, constant2: Constant");
+    }
+
+    auto constant1 = ConstantWrapper::FromValue(info[0])->getConstant();
+    auto constant2 = ConstantWrapper::FromValue(info[1])->getConstant();
+
+    auto constant = llvm::ConstantExpr::getOr(constant1, constant2);
+
+    info.GetReturnValue().Set(ConstantWrapper::of(constant));
+}
+
+NAN_METHOD(ConstantExprWrapper::getPointerBitCastOrAddrSpaceCast) {
+    if (info.Length() != 2 || !ConstantWrapper::isInstance(info[0]) || !TypeWrapper::isInstance(info[1])) {
+        return Nan::ThrowTypeError("getPointerBitCastOrAddrSpaceCast needs to be called with: constant: Constant, type: Type");
+    }
+
+
+    auto constant = ConstantWrapper::FromValue(info[0])->getConstant();
+    auto type = TypeWrapper::FromValue(info[1])->getType();
+
+    auto constantBitCast = llvm::ConstantExpr::getPointerBitCastOrAddrSpaceCast(constant, type);
+
+    info.GetReturnValue().Set(ConstantWrapper::of(constantBitCast));
+}
+
+NAN_METHOD(ConstantExprWrapper::getPointerCast) {
+    if (info.Length() != 2 || !ConstantWrapper::isInstance(info[0]) || !TypeWrapper::isInstance(info[1])) {
+        return Nan::ThrowTypeError("getPointerCast needs to be called with: constant: Constant, type: Type");
+    }
+
+
+    auto constant = ConstantWrapper::FromValue(info[0])->getConstant();
+    auto type = TypeWrapper::FromValue(info[1])->getType();
+
+    auto constantBitCast = llvm::ConstantExpr::getPointerCast(constant, type);
+
+    info.GetReturnValue().Set(ConstantWrapper::of(constantBitCast));
+}

--- a/src/ir/constant-expr.h
+++ b/src/ir/constant-expr.h
@@ -19,9 +19,13 @@ private:
     static Nan::Persistent<v8::FunctionTemplate>& constantExprTemplate();
 
     static NAN_METHOD(New);
+    static NAN_METHOD(getAlignOf);
+    static NAN_METHOD(getSizeOf);
     static NAN_METHOD(getOr);
     static NAN_METHOD(getPointerBitCastOrAddrSpaceCast);
     static NAN_METHOD(getPointerCast);
+    static NAN_METHOD(getIntegerCast);
+    static NAN_METHOD(getFPCast);
 };
 
 #endif //LLVM_NODE_CONSTANT_EXPR_H

--- a/src/ir/constant-expr.h
+++ b/src/ir/constant-expr.h
@@ -26,6 +26,7 @@ private:
     static NAN_METHOD(getPointerCast);
     static NAN_METHOD(getIntegerCast);
     static NAN_METHOD(getFPCast);
+    static NAN_METHOD(getBitCast);
 };
 
 #endif //LLVM_NODE_CONSTANT_EXPR_H

--- a/src/ir/constant-expr.h
+++ b/src/ir/constant-expr.h
@@ -1,0 +1,27 @@
+#ifndef LLVM_NODE_CONSTANT_EXPR_H
+#define LLVM_NODE_CONSTANT_EXPR_H
+
+#include <nan.h>
+#include <llvm/IR/Constants.h>
+#include "constant.h"
+
+class ConstantExprWrapper: public ConstantWrapper, public FromValueMixin<ConstantExprWrapper> {
+public:
+    static NAN_MODULE_INIT(Init);
+    static v8::Local<v8::Object> of(llvm::ConstantExpr* constantExpr);
+    using FromValueMixin<ConstantExprWrapper>::FromValue;
+    llvm::ConstantExpr* getConstantExpr();
+
+private:
+    explicit ConstantExprWrapper(llvm::ConstantExpr* constantExpr) : ConstantWrapper { constantExpr }
+    {}
+
+    static Nan::Persistent<v8::FunctionTemplate>& constantExprTemplate();
+
+    static NAN_METHOD(New);
+    static NAN_METHOD(getOr);
+    static NAN_METHOD(getPointerBitCastOrAddrSpaceCast);
+    static NAN_METHOD(getPointerCast);
+};
+
+#endif //LLVM_NODE_CONSTANT_EXPR_H

--- a/src/ir/ir.cc
+++ b/src/ir/ir.cc
@@ -33,6 +33,7 @@
 #include "visibility-types.h"
 #include "attribute.h"
 #include "undef-value.h"
+#include "constant-expr.h"
 
 NAN_MODULE_INIT(InitIR) {
     AllocaInstWrapper::Init(target);
@@ -47,6 +48,7 @@ NAN_MODULE_INIT(InitIR) {
     ConstantWrapper::Init(target);
     ConstantArrayWrapper::Init(target);
     ConstantDataArrayWrapper::Init(target);
+    ConstantExprWrapper::Init(target);
     ConstantFPWrapper::Init(target);
     ConstantIntWrapper::Init(target);
     ConstantPointerNullWrapper::Init(target);


### PR DESCRIPTION
This adds a `ConstantExpr` class with a few methods, doesn't have tests or most methods added, but I'm making the PR as I was wondering if there's a way to avoid so much duplication of code. Most methods have basically identical code except for the method of `llvm::ConstantExpr` called.

Signed-off-by: Vihan <contact@vihan.org>