### PR TITLE
Add getTypeAllocSize

### DIFF
--- a/llvm-node.d.ts
+++ b/llvm-node.d.ts
@@ -173,6 +173,12 @@ declare namespace llvm {
     isAllOnesValue(): boolean;
   }
 
+  class ConstantExpr extends Constant {
+    static getOr(constant1: Constant, constant2: Constant): ConstantExpr
+    static getPointerBitCastOrAddrSpaceCast(constant: Constant, type: Type): ConstantExpr
+    static getPointerCast(constant: Constant, type: Type): ConstantExpr
+  }
+
   class ConstantFP extends Constant {
     static get(context: LLVMContext, value: number): ConstantFP;
 

--- a/llvm-node.d.ts
+++ b/llvm-node.d.ts
@@ -174,8 +174,12 @@ declare namespace llvm {
   }
 
   class ConstantExpr extends Constant {
+    static getBitCast(constant: Constant, type: Type): ConstantExpr
+
     static getOr(constant1: Constant, constant2: Constant): ConstantExpr
+
     static getPointerBitCastOrAddrSpaceCast(constant: Constant, type: Type): ConstantExpr
+
     static getPointerCast(constant: Constant, type: Type): ConstantExpr
   }
 

--- a/llvm-node.d.ts
+++ b/llvm-node.d.ts
@@ -368,6 +368,8 @@ declare namespace llvm {
 
     getTypeStoreSize(type: Type): number;
 
+    getTypeAllocSize(type: Type): number;
+
     getIntPtrType(context: LLVMContext, as: number): Type;
   }
 

--- a/src/ir/constant-expr.cc
+++ b/src/ir/constant-expr.cc
@@ -38,6 +38,7 @@ Nan::Persistent<v8::FunctionTemplate>& ConstantExprWrapper::constantExprTemplate
         Nan::SetMethod(localTemplate, "getPointerCast", ConstantExprWrapper::getPointerCast);
         Nan::SetMethod(localTemplate, "getIntegerCast", ConstantExprWrapper::getIntegerCast);
         Nan::SetMethod(localTemplate, "getFPCast", ConstantExprWrapper::getFPCast);
+        Nan::SetMethod(localTemplate, "getBitCast", ConstantExprWrapper::getBitCast);
 
         functionTemplate.Reset(localTemplate);
     }
@@ -92,6 +93,19 @@ NAN_METHOD(ConstantExprWrapper::getFPCast) {
     auto type = TypeWrapper::FromValue(info[1])->getType();
 
     auto constantCast = llvm::ConstantExpr::getFPCast(constant, type);
+
+    info.GetReturnValue().Set(ConstantWrapper::of(constantCast));
+}
+
+NAN_METHOD(ConstantExprWrapper::getBitCast) {
+    if (info.Length() != 2 || !ConstantWrapper::isInstance(info[0]) || !TypeWrapper::isInstance(info[1])) {
+        return Nan::ThrowTypeError("getBitCast needs to be called with: constant: Constant, type: Type");
+    }
+
+    auto constant = ConstantWrapper::FromValue(info[0])->getConstant();
+    auto type = TypeWrapper::FromValue(info[1])->getType();
+
+    auto constantCast = llvm::ConstantExpr::getBitCast(constant, type);
 
     info.GetReturnValue().Set(ConstantWrapper::of(constantCast));
 }

--- a/src/ir/constant-expr.cc
+++ b/src/ir/constant-expr.cc
@@ -1,0 +1,99 @@
+#include "constant-expr.h"
+#include "type.h"
+
+
+NAN_MODULE_INIT(ConstantExprWrapper::Init) {
+    auto constantExpr = Nan::GetFunction(Nan::New(constantExprTemplate())).ToLocalChecked();
+
+    Nan::Set(target, Nan::New("ConstantExpr").ToLocalChecked(), constantExpr);
+}
+
+v8::Local<v8::Object> ConstantExprWrapper::of(llvm::ConstantExpr* constantExpr) {
+    auto constructor = Nan::GetFunction(Nan::New(constantExprTemplate())).ToLocalChecked();
+    v8::Local<v8::Value> args[1] = { Nan::New<v8::External> (constantExpr) };
+
+    auto instance = Nan::NewInstance(constructor, 1, args).ToLocalChecked();
+
+    Nan::EscapableHandleScope escapableHandleScope {};
+    return escapableHandleScope.Escape(instance);
+}
+
+llvm::ConstantExpr* ConstantExprWrapper::getConstantExpr() {
+    return static_cast<llvm::ConstantExpr*>(getValue());
+}
+
+Nan::Persistent<v8::FunctionTemplate>& ConstantExprWrapper::constantExprTemplate() {
+    static Nan::Persistent<v8::FunctionTemplate> functionTemplate {};
+
+    if (functionTemplate.IsEmpty()) {
+        v8::Local<v8::FunctionTemplate> localTemplate = Nan::New<v8::FunctionTemplate>(ConstantExprWrapper::New);
+        localTemplate->SetClassName(Nan::New("ConstantExpr").ToLocalChecked());
+        localTemplate->InstanceTemplate()->SetInternalFieldCount(1);
+        localTemplate->Inherit(Nan::New(constantTemplate()));
+
+        Nan::SetMethod(localTemplate, "getOr", ConstantExprWrapper::getOr);
+        Nan::SetMethod(localTemplate, "getPointerBitCastOrAddrSpaceCast", ConstantExprWrapper::getPointerBitCastOrAddrSpaceCast);
+        Nan::SetMethod(localTemplate, "getPointerCast", ConstantExprWrapper::getPointerCast);
+
+        functionTemplate.Reset(localTemplate);
+    }
+
+    return functionTemplate;
+}
+
+NAN_METHOD(ConstantExprWrapper::New) {
+    if (!info.IsConstructCall()) {
+        return Nan::ThrowTypeError("ConstantExpr constructor needs to be called with new");
+    }
+
+    if (!info[0]->IsExternal()) {
+        return Nan::ThrowTypeError("ConstantExpr constructor needs to be called with: constantExpr: External");
+    }
+
+    auto* constantExpr = static_cast<llvm::ConstantExpr*>(v8::External::Cast(*info[0])->Value());
+    auto* wrapper = new ConstantExprWrapper { constantExpr };
+    wrapper->Wrap(info.This());
+
+    info.GetReturnValue().Set(info.This());
+}
+
+NAN_METHOD(ConstantExprWrapper::getOr) {
+    if (info.Length() != 2 || !ConstantWrapper::isInstance(info[0]) || !ConstantWrapper::isInstance(info[1])) {
+        return Nan::ThrowTypeError("getOr needs to be called with: constant1: Constant, constant2: Constant");
+    }
+
+    auto constant1 = ConstantWrapper::FromValue(info[0])->getConstant();
+    auto constant2 = ConstantWrapper::FromValue(info[1])->getConstant();
+
+    auto constant = llvm::ConstantExpr::getOr(constant1, constant2);
+
+    info.GetReturnValue().Set(ConstantWrapper::of(constant));
+}
+
+NAN_METHOD(ConstantExprWrapper::getPointerBitCastOrAddrSpaceCast) {
+    if (info.Length() != 2 || !ConstantWrapper::isInstance(info[0]) || !TypeWrapper::isInstance(info[1])) {
+        return Nan::ThrowTypeError("getPointerBitCastOrAddrSpaceCast needs to be called with: constant: Constant, type: Type");
+    }
+
+
+    auto constant = ConstantWrapper::FromValue(info[0])->getConstant();
+    auto type = TypeWrapper::FromValue(info[1])->getType();
+
+    auto constantBitCast = llvm::ConstantExpr::getPointerBitCastOrAddrSpaceCast(constant, type);
+
+    info.GetReturnValue().Set(ConstantWrapper::of(constantBitCast));
+}
+
+NAN_METHOD(ConstantExprWrapper::getPointerCast) {
+    if (info.Length() != 2 || !ConstantWrapper::isInstance(info[0]) || !TypeWrapper::isInstance(info[1])) {
+        return Nan::ThrowTypeError("getPointerCast needs to be called with: constant: Constant, type: Type");
+    }
+
+
+    auto constant = ConstantWrapper::FromValue(info[0])->getConstant();
+    auto type = TypeWrapper::FromValue(info[1])->getType();
+
+    auto constantBitCast = llvm::ConstantExpr::getPointerCast(constant, type);
+
+    info.GetReturnValue().Set(ConstantWrapper::of(constantBitCast));
+}

--- a/src/ir/constant-expr.h
+++ b/src/ir/constant-expr.h
@@ -19,9 +19,13 @@ private:
     static Nan::Persistent<v8::FunctionTemplate>& constantExprTemplate();
 
     static NAN_METHOD(New);
+    static NAN_METHOD(getAlignOf);
+    static NAN_METHOD(getSizeOf);
     static NAN_METHOD(getOr);
     static NAN_METHOD(getPointerBitCastOrAddrSpaceCast);
     static NAN_METHOD(getPointerCast);
+    static NAN_METHOD(getIntegerCast);
+    static NAN_METHOD(getFPCast);
 };
 
 #endif //LLVM_NODE_CONSTANT_EXPR_H

--- a/src/ir/constant-expr.h
+++ b/src/ir/constant-expr.h
@@ -26,6 +26,7 @@ private:
     static NAN_METHOD(getPointerCast);
     static NAN_METHOD(getIntegerCast);
     static NAN_METHOD(getFPCast);
+    static NAN_METHOD(getBitCast);
 };
 
 #endif //LLVM_NODE_CONSTANT_EXPR_H

--- a/src/ir/constant-expr.h
+++ b/src/ir/constant-expr.h
@@ -1,0 +1,27 @@
+#ifndef LLVM_NODE_CONSTANT_EXPR_H
+#define LLVM_NODE_CONSTANT_EXPR_H
+
+#include <nan.h>
+#include <llvm/IR/Constants.h>
+#include "constant.h"
+
+class ConstantExprWrapper: public ConstantWrapper, public FromValueMixin<ConstantExprWrapper> {
+public:
+    static NAN_MODULE_INIT(Init);
+    static v8::Local<v8::Object> of(llvm::ConstantExpr* constantExpr);
+    using FromValueMixin<ConstantExprWrapper>::FromValue;
+    llvm::ConstantExpr* getConstantExpr();
+
+private:
+    explicit ConstantExprWrapper(llvm::ConstantExpr* constantExpr) : ConstantWrapper { constantExpr }
+    {}
+
+    static Nan::Persistent<v8::FunctionTemplate>& constantExprTemplate();
+
+    static NAN_METHOD(New);
+    static NAN_METHOD(getOr);
+    static NAN_METHOD(getPointerBitCastOrAddrSpaceCast);
+    static NAN_METHOD(getPointerCast);
+};
+
+#endif //LLVM_NODE_CONSTANT_EXPR_H

--- a/src/ir/data-layout.cc
+++ b/src/ir/data-layout.cc
@@ -5,6 +5,7 @@
 #include "../util/string.h"
 #include "data-layout.h"
 #include "type.h"
+#include "integer-type.h"
 
 Nan::Persistent<v8::FunctionTemplate> DataLayoutWrapper::functionTemplate {};
 
@@ -123,7 +124,7 @@ NAN_METHOD(DataLayoutWrapper::getIntPtrType) {
     }
 
     auto* type = dataLayout.getIntPtrType(context, addressSpace);
-    info.GetReturnValue().Set(TypeWrapper::of(type));
+    info.GetReturnValue().Set(IntegerTypeWrapper::of(type));
 }
 
 llvm::DataLayout DataLayoutWrapper::getDataLayout() {

--- a/src/ir/data-layout.cc
+++ b/src/ir/data-layout.cc
@@ -27,6 +27,7 @@ NAN_MODULE_INIT(DataLayoutWrapper::Init) {
     Nan::SetPrototypeMethod(tpl, "getStringRepresentation", DataLayoutWrapper::getStringRepresentation);
     Nan::SetPrototypeMethod(tpl, "getPrefTypeAlignment", DataLayoutWrapper::getPrefTypeAlignment);
     Nan::SetPrototypeMethod(tpl, "getTypeStoreSize", DataLayoutWrapper::getTypeStoreSize);
+    Nan::SetPrototypeMethod(tpl, "getTypeAllocSize", DataLayoutWrapper::getTypeAllocSize);
     Nan::SetPrototypeMethod(tpl, "getPointerSize", DataLayoutWrapper::getPointerSize);
     Nan::SetPrototypeMethod(tpl, "getIntPtrType", DataLayoutWrapper::getIntPtrType);
 
@@ -87,6 +88,20 @@ NAN_METHOD(DataLayoutWrapper::getTypeStoreSize) {
     auto dataLayout = DataLayoutWrapper::FromValue(info.Holder())->getDataLayout();
 
     auto size = dataLayout.getTypeStoreSize(type);
+     assert (size < UINT32_MAX && "V8 does not support uint64 but size overflows uint32"); // v8 does not support uint64_t :(
+
+    info.GetReturnValue().Set(Nan::New(static_cast<uint32_t>(size)));
+}
+
+NAN_METHOD(DataLayoutWrapper::getTypeAllocSize) {
+    if (info.Length() != 1 || !TypeWrapper::isInstance(info[0])) {
+        return Nan::ThrowTypeError("getTypeAllocSize needs to be called with: type: Type");
+    }
+
+    auto* type = TypeWrapper::FromValue(info[0])->getType();
+    auto dataLayout = DataLayoutWrapper::FromValue(info.Holder())->getDataLayout();
+
+    auto size = dataLayout.getTypeAllocSize(type);
      assert (size < UINT32_MAX && "V8 does not support uint64 but size overflows uint32"); // v8 does not support uint64_t :(
 
     info.GetReturnValue().Set(Nan::New(static_cast<uint32_t>(size)));

--- a/src/ir/data-layout.h
+++ b/src/ir/data-layout.h
@@ -28,6 +28,7 @@ private:
     static NAN_METHOD(getPointerSize);
     static NAN_METHOD(getPrefTypeAlignment);
     static NAN_METHOD(getTypeStoreSize);
+    static NAN_METHOD(getTypeAllocSize);
     static NAN_METHOD(getIntPtrType);
 };
 

--- a/src/ir/integer-type.cc
+++ b/src/ir/integer-type.cc
@@ -1,0 +1,80 @@
+#include "integer-type.h"
+
+NAN_MODULE_INIT(IntegerTypeWrapper::Init) {
+    auto integerType = Nan::GetFunction(Nan::New(integerTypeTemplate())).ToLocalChecked();
+    Nan::Set(target, Nan::New("IntegerType").ToLocalChecked(), integerType);
+}
+
+NAN_METHOD(IntegerTypeWrapper::New) {
+    if (!info.IsConstructCall()) {
+        return Nan::ThrowTypeError("Constructor needs to be called with new");
+    }
+
+    if (info.Length() < 1 || !info[0]->IsExternal()) {
+        return Nan::ThrowTypeError("Expected pointer type pointer");
+    }
+
+    auto* type = static_cast<llvm::IntegerType*>(v8::External::Cast(*info[0])->Value());
+    auto* wrapper = new IntegerTypeWrapper { type };
+    wrapper->Wrap(info.This());
+
+    info.GetReturnValue().Set(info.This());
+}
+
+NAN_METHOD(IntegerTypeWrapper::get) {
+    if (info.Length() != 2 || !LLVMContextWrapper::isInstance(info[0]) || !info[1]->IsUint32()) {
+        return Nan::ThrowTypeError("IntegerTypeWrapper.get needs to be called with: context: LLVMContext, bitWidth: uint32");
+    }
+
+    auto& context = LLVMContextWrapper::FromValue(info[0])->getContext();
+    uint32_t bitWidth = Nan::To<uint32_t>(info[1]).FromJust();
+
+    auto* integerType = llvm::IntegerType::get(context, bitWidth);
+
+    info.GetReturnValue().Set(IntegerTypeWrapper::of(integerType));
+}
+
+NAN_GETTER(IntegerTypeWrapper::getBitWidth) {
+    auto* integerType = IntegerTypeWrapper::FromValue(info.Holder())->getIntegerType();
+    uint32_t bitWidth = integerType->getBitWidth();
+
+    info.GetReturnValue().Set(Nan::New(bitWidth));
+}
+
+v8::Local<v8::Object> IntegerTypeWrapper::of(llvm::IntegerType *type) {
+    Nan::EscapableHandleScope escapeScope {};
+
+    v8::Local<v8::FunctionTemplate> functionTemplate = Nan::New(integerTypeTemplate());
+    auto constructorFunction = Nan::GetFunction(functionTemplate).ToLocalChecked();
+    v8::Local<v8::Value> argv[1] = { Nan::New<v8::External>(type) };
+    v8::Local<v8::Object> object = Nan::NewInstance(constructorFunction, 1, argv).ToLocalChecked();
+
+    return escapeScope.Escape(object);
+}
+
+Nan::Persistent<v8::FunctionTemplate>& IntegerTypeWrapper::integerTypeTemplate() {
+    static Nan::Persistent<v8::FunctionTemplate> persistentTemplate {};
+
+    if (persistentTemplate.IsEmpty()) {
+        v8::Local<v8::FunctionTemplate> integerTypeTemplate = Nan::New<v8::FunctionTemplate>(IntegerTypeWrapper::New);
+
+        Nan::SetMethod(integerTypeTemplate, "get", IntegerTypeWrapper::get);
+        integerTypeTemplate->SetClassName(Nan::New("IntegerType").ToLocalChecked());
+        integerTypeTemplate->InstanceTemplate()->SetInternalFieldCount(1);
+        integerTypeTemplate->Inherit(Nan::New(typeTemplate()));
+
+        Nan::SetAccessor(integerTypeTemplate->InstanceTemplate(), Nan::New("bitWidth").ToLocalChecked(), IntegerTypeWrapper::getBitWidth);
+
+        persistentTemplate.Reset(integerTypeTemplate);
+    }
+
+    return persistentTemplate;
+}
+
+bool IntegerTypeWrapper::isInstance(v8::Local<v8::Value> object) {
+    return Nan::New(integerTypeTemplate())->HasInstance(object);
+}
+
+llvm::IntegerType *IntegerTypeWrapper::getIntegerType() {
+    return static_cast<llvm::IntegerType*>(getType());
+}

--- a/src/ir/integer-type.h
+++ b/src/ir/integer-type.h
@@ -1,0 +1,34 @@
+#ifndef LLVM_NODE_INTEGER_TYPE_H
+#define LLVM_NODE_INTEGER_TYPE_H
+
+#include <nan.h>
+#include <llvm/IR/Type.h>
+#include <llvm/IR/DerivedTypes.h>
+#include "llvm-context.h"
+#include "../util/from-value-mixin.h"
+#include "type.h"
+
+class IntegerTypeWrapper: public TypeWrapper, public FromValueMixin<IntegerTypeWrapper> {
+public:
+    static NAN_MODULE_INIT(Init);
+    static v8::Local<v8::Object> of(llvm::IntegerType *type);
+    using FromValueMixin<IntegerTypeWrapper>::FromValue;
+
+    llvm::IntegerType* getIntegerType();
+    static bool isInstance(v8::Local<v8::Value> value);
+
+protected:
+    llvm::Type* type;
+    explicit IntegerTypeWrapper(llvm::IntegerType* type) : TypeWrapper { type } {
+    }
+
+    static Nan::Persistent<v8::FunctionTemplate>& integerTypeTemplate();
+
+private:
+    // Static Methods
+    static NAN_METHOD(New);
+    static NAN_METHOD(get);
+    static NAN_GETTER(getBitWidth);
+};
+
+#endif //LLVM_NODE_INTEGER_TYPE_H

--- a/src/ir/ir.cc
+++ b/src/ir/ir.cc
@@ -34,6 +34,7 @@
 #include "attribute.h"
 #include "undef-value.h"
 #include "constant-expr.h"
+#include "integer-type.h"
 
 NAN_MODULE_INIT(InitIR) {
     AllocaInstWrapper::Init(target);
@@ -58,6 +59,7 @@ NAN_MODULE_INIT(InitIR) {
     GlobalVariableWrapper::Init(target);
     IRBuilderWrapper::Init(target);
     InitLinkageTypes(target);
+    IntegerTypeWrapper::Init(target);
     ModuleWrapper::Init(target);
     LLVMContextWrapper::Init(target);
     PhiNodeWrapper::Init(target);

--- a/src/ir/ir.cc
+++ b/src/ir/ir.cc
@@ -33,6 +33,7 @@
 #include "visibility-types.h"
 #include "attribute.h"
 #include "undef-value.h"
+#include "constant-expr.h"
 
 NAN_MODULE_INIT(InitIR) {
     AllocaInstWrapper::Init(target);
@@ -47,6 +48,7 @@ NAN_MODULE_INIT(InitIR) {
     ConstantWrapper::Init(target);
     ConstantArrayWrapper::Init(target);
     ConstantDataArrayWrapper::Init(target);
+    ConstantExprWrapper::Init(target);
     ConstantFPWrapper::Init(target);
     ConstantIntWrapper::Init(target);
     ConstantPointerNullWrapper::Init(target);

--- a/src/ir/type.cc
+++ b/src/ir/type.cc
@@ -9,6 +9,7 @@
 #include "pointer-type.h"
 #include "array-type.h"
 #include "struct-type.h"
+#include "integer-type.h"
 
 NAN_MODULE_INIT(TypeWrapper::Init) {
     auto type = Nan::GetFunction(Nan::New(typeTemplate())).ToLocalChecked();
@@ -149,6 +150,8 @@ v8::Local<v8::Object> TypeWrapper::of(llvm::Type *type) {
         result = ArrayTypeWrapper::of(static_cast<llvm::ArrayType*>(type));
     } else if (type->isStructTy()) {
         result = StructTypeWrapper::of(static_cast<llvm::StructType*>(type));
+    } else if (type->isIntegerTy()) {
+        result = IntegerTypeWrapper::of(static_cast<llvm::IntegerType*>(type));
     } else {
         v8::Local<v8::FunctionTemplate> functionTemplate = Nan::New(typeTemplate());
         auto constructorFunction = Nan::GetFunction(functionTemplate).ToLocalChecked();
@@ -253,4 +256,3 @@ bool TypeWrapper::isInstance(v8::Local<v8::Value> object) {
 llvm::Type *TypeWrapper::getType() {
     return type;
 }
-


### PR DESCRIPTION
Adds the `DataLayout.getTypeAllocSize()` to `DataLayout`, useful for things like `malloc()` etc.