### PR TITLE
Handle null insert block returned by IRBuilder

### DIFF
--- a/llvm-node.d.ts
+++ b/llvm-node.d.ts
@@ -628,7 +628,7 @@ declare namespace llvm {
 
     createZExt(value: Value, destType: Type, name?: string): Value;
 
-    getInsertBlock(): BasicBlock;
+    getInsertBlock(): BasicBlock | undefined;
   }
 
   class LLVMContext {

--- a/src/ir/ir-builder.cc
+++ b/src/ir/ir-builder.cc
@@ -637,7 +637,12 @@ NAN_METHOD(IRBuilderWrapper::CreateSelect) {
 NAN_METHOD(IRBuilderWrapper::GetInsertBlock) {
     auto* builder = IRBuilderWrapper::FromValue(info.Holder());
     auto* block = builder->irBuilder.GetInsertBlock();
-    info.GetReturnValue().Set(BasicBlockWrapper::of(block));
+
+    if (block) {
+        return info.GetReturnValue().Set(BasicBlockWrapper::of(block));
+    }
+
+    info.GetReturnValue().Set(Nan::Undefined());
 }
 
 NAN_METHOD(IRBuilderWrapper::SetInsertionPoint) {

--- a/test/ir/ir-builder.spec.ts
+++ b/test/ir/ir-builder.spec.ts
@@ -1,5 +1,5 @@
 import * as llvm from "../../";
-import { createBuilderWithBlock } from "../test-utils";
+import { createBuilder, createBuilderWithBlock } from "../test-utils";
 
 describe("IRBuilder", () => {
   test("createAdd returns a value", () => {
@@ -841,5 +841,11 @@ describe("IRBuilder", () => {
     builder.setInsertionPoint(block);
 
     expect(builder.getInsertBlock()).toEqual(block);
+  });
+
+  test("getInsertBlock returns undefined if insertion point has not been set", () => {
+    const { builder } = createBuilder();
+
+    expect(builder.getInsertBlock()).toBeUndefined();
   });
 });


### PR DESCRIPTION
Currently the code segfaults when trying to access the return value of getInsertBlock when there's no insert block. I think this should fix it.