### PR TITLE
Fix type definition of StructType's "name" property to include undefined

### DIFF
--- a/llvm-node.d.ts
+++ b/llvm-node.d.ts
@@ -481,7 +481,7 @@ declare namespace llvm {
 
     static get(context: LLVMContext, elements: Type[], isPacked?: boolean): StructType;
 
-    name: string;
+    name: string | undefined;
     readonly numElements: number;
 
     private constructor();

--- a/test/ir/struct-type.spec.ts
+++ b/test/ir/struct-type.spec.ts
@@ -38,6 +38,14 @@ describe("ir/struct-type", () => {
 
       expect(structType.name).toBe("name");
     });
+
+    it("returns undefined for literal struct types", () => {
+      const { context } = createModule();
+
+      const structType = llvm.StructType.get(context, [llvm.Type.getInt32Ty(context)]);
+
+      expect(structType.name).toBeUndefined();
+    });
   });
 
   describe("numElements", () => {


### PR DESCRIPTION
Definition of the name getter returning undefined:

https://github.com/MichaReiser/llvm-node/blob/7695626fbc4d2f9c1b673ba7bffc6fea1f31f43e/src/ir/struct-type.cc#L98