### PR TITLE
Remove duplication in ValueWrapper derived class definitions with macros

### DIFF
--- a/src/ir/alloca-inst.cc
+++ b/src/ir/alloca-inst.cc
@@ -10,14 +10,7 @@ NAN_MODULE_INIT(AllocaInstWrapper::Init) {
     Nan::Set(target, Nan::New("AllocaInst").ToLocalChecked(), allocaInst);
 }
 
-v8::Local<v8::Object> AllocaInstWrapper::of(llvm::AllocaInst* inst) {
-    auto constructorFunction = Nan::GetFunction(Nan::New(allocaInstTemplate())).ToLocalChecked();
-    v8::Local<v8::Value> args[1] = { Nan::New<v8::External>(inst) };
-    auto instance = Nan::NewInstance(constructorFunction, 1, args).ToLocalChecked();
-
-    Nan::EscapableHandleScope escapeScope {};
-    return escapeScope.Escape(instance);
-}
+VALUE_WRAPPER_OF_DEFINITION(AllocaInst, AllocaInst, allocaInst)
 
 NAN_METHOD(AllocaInstWrapper::New) {
     if (!info.IsConstructCall()) {

--- a/src/ir/alloca-inst.cc
+++ b/src/ir/alloca-inst.cc
@@ -19,10 +19,6 @@ v8::Local<v8::Object> AllocaInstWrapper::of(llvm::AllocaInst* inst) {
     return escapeScope.Escape(instance);
 }
 
-llvm::AllocaInst* AllocaInstWrapper::getAllocaInst() {
-    return static_cast<llvm::AllocaInst*>(getValue());
-}
-
 NAN_METHOD(AllocaInstWrapper::New) {
     if (!info.IsConstructCall()) {
         return Nan::ThrowTypeError("Class Constructor AllocaInst cannot be invoked without new");

--- a/src/ir/alloca-inst.h
+++ b/src/ir/alloca-inst.h
@@ -5,30 +5,16 @@
 #ifndef LLVM_NODE_ALLOCAINST_H
 #define LLVM_NODE_ALLOCAINST_H
 
-#include <nan.h>
 #include <llvm/IR/Instructions.h>
-#include "value.h"
+#include "value-wrapper-template.h"
 
-class AllocaInstWrapper: public ValueWrapper, public FromValueMixin<AllocaInstWrapper> {
-public:
-    using FromValueMixin<AllocaInstWrapper>::FromValue;
-
-    static NAN_MODULE_INIT(Init);
-    static v8::Local<v8::Object> of(llvm::AllocaInst* allocaInst);
-    llvm::AllocaInst* getAllocaInst();
-
-private:
-    explicit AllocaInstWrapper(llvm::AllocaInst* allocaInst): ValueWrapper { allocaInst } {
-    }
-
+VALUE_WRAPPER_TEMPLATE_BEGIN(AllocaInst, AllocaInst, allocaInst, Value, private)
     static NAN_METHOD(New);
     static NAN_GETTER(getAllocatedType);
     static NAN_SETTER(setAllocatedType);
     static NAN_GETTER(getAlignment);
     static NAN_SETTER(setAlignment);
     static NAN_GETTER(getArraySize);
-    static Nan::Persistent<v8::FunctionTemplate>& allocaInstTemplate();
-};
-
+VALUE_WRAPPER_TEMPLATE_END
 
 #endif //LLVM_NODE_ALLOCAINST_H

--- a/src/ir/argument.cc
+++ b/src/ir/argument.cc
@@ -134,10 +134,6 @@ NAN_METHOD(ArgumentWrapper::addDereferenceableAttr) {
 #endif
 }
 
-llvm::Argument *ArgumentWrapper::getArgument() {
-    return static_cast<llvm::Argument*>(ValueWrapper::getValue());
-}
-
 v8::Local<v8::Object> ArgumentWrapper::of(llvm::Argument *argument) {
     Nan::EscapableHandleScope escapeScope {};
 
@@ -147,4 +143,9 @@ v8::Local<v8::Object> ArgumentWrapper::of(llvm::Argument *argument) {
     auto instance = Nan::NewInstance(constructorFunction, 1, args).ToLocalChecked();
 
     return escapeScope.Escape(instance);
+}
+
+Nan::Persistent<v8::FunctionTemplate>& ArgumentWrapper::argumentTemplate() {
+    static Nan::Persistent<v8::FunctionTemplate> functionTemplate {};
+    return functionTemplate;
 }

--- a/src/ir/argument.cc
+++ b/src/ir/argument.cc
@@ -134,16 +134,7 @@ NAN_METHOD(ArgumentWrapper::addDereferenceableAttr) {
 #endif
 }
 
-v8::Local<v8::Object> ArgumentWrapper::of(llvm::Argument *argument) {
-    Nan::EscapableHandleScope escapeScope {};
-
-    auto functionTemplate = Nan::New(argumentTemplate());
-    auto constructorFunction = Nan::GetFunction(functionTemplate).ToLocalChecked();
-    v8::Local<v8::Value> args[1] = { Nan::New<v8::External>(argument) };
-    auto instance = Nan::NewInstance(constructorFunction, 1, args).ToLocalChecked();
-
-    return escapeScope.Escape(instance);
-}
+VALUE_WRAPPER_OF_DEFINITION(Argument, Argument, argument)
 
 Nan::Persistent<v8::FunctionTemplate>& ArgumentWrapper::argumentTemplate() {
     static Nan::Persistent<v8::FunctionTemplate> functionTemplate {};

--- a/src/ir/argument.h
+++ b/src/ir/argument.h
@@ -5,36 +5,16 @@
 #ifndef LLVM_NODE_ARGUMENT_H
 #define LLVM_NODE_ARGUMENT_H
 
-#include <nan.h>
 #include <llvm/IR/Argument.h>
-#include "value.h"
-#include "../util/from-value-mixin.h"
+#include "value-wrapper-template.h"
 
-class ArgumentWrapper: public ValueWrapper, public FromValueMixin<ArgumentWrapper> {
-public:
-    llvm::Argument* getArgument();
-
-    static NAN_MODULE_INIT(Init);
-    static v8::Local<v8::Object> of(llvm::Argument* argument);
-    using FromValueMixin<ArgumentWrapper>::FromValue;
-
-private:
-    explicit ArgumentWrapper(llvm::Argument *argument)
-        : ValueWrapper { argument }
-    {}
-
+VALUE_WRAPPER_TEMPLATE_BEGIN(Argument, Argument, argument, Value, private)
     static NAN_METHOD(New);
     static NAN_GETTER(getArgNo);
     static NAN_GETTER(getParent);
     static NAN_METHOD(addAttr);
     static NAN_METHOD(hasAttribute);
     static NAN_METHOD(addDereferenceableAttr);
-
-    static inline Nan::Persistent<v8::FunctionTemplate>& argumentTemplate() {
-        static Nan::Persistent<v8::FunctionTemplate> functionTemplate {};
-        return functionTemplate;
-    }
-};
-
+VALUE_WRAPPER_TEMPLATE_END
 
 #endif //LLVM_NODE_ARGUMENT_H

--- a/src/ir/basic-block.cc
+++ b/src/ir/basic-block.cc
@@ -13,14 +13,7 @@ NAN_MODULE_INIT(BasicBlockWrapper::Init) {
     Nan::Set(target, Nan::New("BasicBlock").ToLocalChecked(), basicBlock);
 }
 
-v8::Local<v8::Object> BasicBlockWrapper::of(llvm::BasicBlock *basicBlock) {
-    auto constructorFunction = Nan::GetFunction(Nan::New(basicBlockTemplate())).ToLocalChecked();
-    v8::Local<v8::Value> argv[1] = { Nan::New<v8::External>(basicBlock) };
-    auto instance = Nan::NewInstance(constructorFunction, 1, argv).ToLocalChecked();
-
-    Nan::EscapableHandleScope escapeScope {};
-    return escapeScope.Escape(instance);
-}
+VALUE_WRAPPER_OF_DEFINITION(BasicBlock, BasicBlock, basicBlock)
 
 NAN_METHOD(BasicBlockWrapper::New) {
     if (!info.IsConstructCall()) {

--- a/src/ir/basic-block.h
+++ b/src/ir/basic-block.h
@@ -5,25 +5,10 @@
 #ifndef LLVM_NODE_BASICBLOCKWRAPPER_H
 #define LLVM_NODE_BASICBLOCKWRAPPER_H
 
-#include <nan.h>
 #include <llvm/IR/BasicBlock.h>
-#include "value.h"
+#include "value-wrapper-template.h"
 
-class BasicBlockWrapper: public ValueWrapper, public FromValueMixin<BasicBlockWrapper> {
-public:
-    static NAN_MODULE_INIT(Init);
-    static v8::Local<v8::Object> of(llvm::BasicBlock* basicBlock);
-    static bool isInstance(v8::Local<v8::Value> value);
-    using FromValueMixin<BasicBlockWrapper>::FromValue;
-    inline llvm::BasicBlock* getBasicBlock() {
-        return static_cast<llvm::BasicBlock*>(getValue());
-    }
-
-private:
-    explicit BasicBlockWrapper(llvm::BasicBlock* basicBlock)
-            : ValueWrapper { basicBlock }
-    {}
-
+VALUE_WRAPPER_TEMPLATE_BEGIN(BasicBlock, BasicBlock, basicBlock, Value, private)
     // static methods
     static NAN_METHOD(New);
     static NAN_METHOD(Create);
@@ -35,8 +20,8 @@ private:
     static NAN_METHOD(getTerminator);
     static NAN_GETTER(getContext);
 
-    static Nan::Persistent<v8::FunctionTemplate>& basicBlockTemplate();
-};
-
+public:
+    static bool isInstance(v8::Local<v8::Value> value);
+VALUE_WRAPPER_TEMPLATE_END
 
 #endif //LLVM_NODE_BASICBLOCKWRAPPER_H

--- a/src/ir/call-inst.cc
+++ b/src/ir/call-inst.cc
@@ -10,14 +10,7 @@ NAN_MODULE_INIT(CallInstWrapper::Init) {
     Nan::Set(target, Nan::New("CallInst").ToLocalChecked(), callInstruction);
 }
 
-v8::Local<v8::Object> CallInstWrapper::of(llvm::CallInst* inst) {
-    Nan::EscapableHandleScope escapeScope {};
-    auto constructorFunction = Nan::GetFunction(Nan::New(callInstTemplate())).ToLocalChecked();
-    v8::Local<v8::Value> args[1] = { Nan::New<v8::External>(inst) };
-    auto instance = Nan::NewInstance(constructorFunction, 1, args).ToLocalChecked();
-
-    return escapeScope.Escape(instance);
-}
+VALUE_WRAPPER_OF_DEFINITION(CallInst, CallInst, callInst)
 
 bool CallInstWrapper::isInstance(v8::Local<v8::Value> value) {
     return Nan::New(callInstTemplate())->HasInstance(value);

--- a/src/ir/call-inst.cc
+++ b/src/ir/call-inst.cc
@@ -23,10 +23,6 @@ bool CallInstWrapper::isInstance(v8::Local<v8::Value> value) {
     return Nan::New(callInstTemplate())->HasInstance(value);
 }
 
-llvm::CallInst* CallInstWrapper::getCallInst() {
-    return static_cast<llvm::CallInst*>(getValue());
-}
-
 NAN_METHOD(CallInstWrapper::New) {
     if (!info.IsConstructCall()) {
         return Nan::ThrowTypeError("CallInst Constructor needs to be called with new");

--- a/src/ir/call-inst.h
+++ b/src/ir/call-inst.h
@@ -5,19 +5,10 @@
 #ifndef LLVM_NODE_CALL_INST_H
 #define LLVM_NODE_CALL_INST_H
 
-#include <nan.h>
 #include <llvm/IR/Instructions.h>
-#include "value.h"
+#include "value-wrapper-template.h"
 
-class CallInstWrapper: public ValueWrapper, public FromValueMixin<CallInstWrapper> {
-public:
-    static NAN_MODULE_INIT(Init);
-    static v8::Local<v8::Object> of(llvm::CallInst* callInst);
-    static bool isInstance(v8::Local<v8::Value> value);
-    using FromValueMixin<CallInstWrapper>::FromValue;
-    llvm::CallInst* getCallInst();
-
-private:
+VALUE_WRAPPER_TEMPLATE_BEGIN(CallInst, CallInst, callInst, Value, private)
     static NAN_METHOD(New);
 
     static NAN_GETTER(getCallingConv);
@@ -27,9 +18,8 @@ private:
     static NAN_METHOD(paramHasAttr);
     static NAN_METHOD(getNumArgOperands);
 
-    explicit CallInstWrapper(llvm::CallInst* value) : ValueWrapper { value } {}
-
-    static Nan::Persistent<v8::FunctionTemplate>& callInstTemplate();
-};
+public:
+    static bool isInstance(v8::Local<v8::Value> value);
+VALUE_WRAPPER_TEMPLATE_END
 
 #endif //LLVM_NODE_CALL_INST_H

--- a/src/ir/constant-array.cc
+++ b/src/ir/constant-array.cc
@@ -10,15 +10,7 @@ NAN_MODULE_INIT(ConstantArrayWrapper::Init) {
     Nan::Set(target, Nan::New("ConstantArray").ToLocalChecked(), constantArray);
 }
 
-v8::Local<v8::Object> ConstantArrayWrapper::of(llvm::ConstantArray* constantArray) {
-    auto constructorFunction = Nan::GetFunction(Nan::New(constantArrayTemplate())).ToLocalChecked();
-    v8::Local<v8::Value> args[1] = { Nan::New<v8::External>(constantArray)};
-
-    auto instance = Nan::NewInstance(constructorFunction, 1, args).ToLocalChecked();
-
-    Nan::EscapableHandleScope escapableHandleScope {};
-    return escapableHandleScope.Escape(instance);
-}
+VALUE_WRAPPER_OF_DEFINITION(ConstantArray, ConstantArray, constantArray)
 
 Nan::Persistent<v8::FunctionTemplate>& ConstantArrayWrapper::constantArrayTemplate() {
     static Nan::Persistent<v8::FunctionTemplate> functionTemplate {};

--- a/src/ir/constant-array.h
+++ b/src/ir/constant-array.h
@@ -6,25 +6,13 @@
 #define LLVM_NODE_CONSTANT_ARRAY_H
 
 #include <nan.h>
-#include "../util/from-value-mixin.h"
 #include "constant.h"
+#include "value-wrapper-template.h"
 
-class ConstantArrayWrapper: public ConstantWrapper, public FromValueMixin<ConstantArrayWrapper> {
-public:
-    static NAN_MODULE_INIT(Init);
-    static v8::Local<v8::Object> of(llvm::ConstantArray* constantArray);
-    using FromValueMixin<ConstantArrayWrapper>::FromValue;
-
-private:
-    explicit ConstantArrayWrapper(llvm::ConstantArray* array)
-            : ConstantWrapper { array }
-    {}
-
-    static Nan::Persistent<v8::FunctionTemplate>& constantArrayTemplate();
-
+VALUE_WRAPPER_TEMPLATE_BEGIN(ConstantArray, ConstantArray, constantArray, Constant, private)
     // static
     static NAN_METHOD(New);
     static NAN_METHOD(get);
-};
+VALUE_WRAPPER_TEMPLATE_END
 
 #endif //LLVM_NODE_CONSTANT_ARRAY_H

--- a/src/ir/constant-data-array.cc
+++ b/src/ir/constant-data-array.cc
@@ -12,14 +12,7 @@ NAN_MODULE_INIT(ConstantDataArrayWrapper::Init) {
     Nan::Set(target, Nan::New("ConstantDataArray").ToLocalChecked(), constantDataArray);
 }
 
-v8::Local<v8::Object> ConstantDataArrayWrapper::of(llvm::ConstantDataArray* constantDataArray) {
-    Nan::EscapableHandleScope escapeScope {};
-    auto constuctorFunction = Nan::GetFunction(Nan::New(constantDataArrayTemplate())).ToLocalChecked();
-    v8::Local<v8::Value> args[1] = { Nan::New<v8::External>(constantDataArray) };
-    auto instance = Nan::NewInstance(constuctorFunction, 1, args).ToLocalChecked();
-
-    return escapeScope.Escape(instance);
-}
+VALUE_WRAPPER_OF_DEFINITION(ConstantDataArray, ConstantDataArray, constantDataArray)
 
 Nan::Persistent<v8::FunctionTemplate>& ConstantDataArrayWrapper::constantDataArrayTemplate() {
     static Nan::Persistent<v8::FunctionTemplate> functionTemplate {};

--- a/src/ir/constant-data-array.cc
+++ b/src/ir/constant-data-array.cc
@@ -21,10 +21,6 @@ v8::Local<v8::Object> ConstantDataArrayWrapper::of(llvm::ConstantDataArray* cons
     return escapeScope.Escape(instance);
 }
 
-llvm::ConstantDataArray* ConstantDataArrayWrapper::getConstantDataArray() {
-    return static_cast<llvm::ConstantDataArray*>(getValue());
-}
-
 Nan::Persistent<v8::FunctionTemplate>& ConstantDataArrayWrapper::constantDataArrayTemplate() {
     static Nan::Persistent<v8::FunctionTemplate> functionTemplate {};
 

--- a/src/ir/constant-data-array.h
+++ b/src/ir/constant-data-array.h
@@ -5,28 +5,15 @@
 #ifndef LLVM_NODE_CONSTANT_DATA_ARRAY_H
 #define LLVM_NODE_CONSTANT_DATA_ARRAY_H
 
-#include <nan.h>
 #include <llvm/IR/Constants.h>
 #include "constant.h"
+#include "value-wrapper-template.h"
 
-class ConstantDataArrayWrapper: public ConstantWrapper, public FromValueMixin<ConstantDataArrayWrapper> {
-public:
-    static NAN_MODULE_INIT(Init);
-    static v8::Local<v8::Object> of(llvm::ConstantDataArray* constantDataArray);
-    using FromValueMixin<ConstantDataArrayWrapper>::FromValue;
-    llvm::ConstantDataArray* getConstantDataArray();
-
-private:
-    explicit ConstantDataArrayWrapper(llvm::ConstantDataArray* constant)
-            : ConstantWrapper { constant }
-    {}
-
-    static Nan::Persistent<v8::FunctionTemplate>& constantDataArrayTemplate();
-
+VALUE_WRAPPER_TEMPLATE_BEGIN(ConstantDataArray, ConstantDataArray, constantDataArray, Constant, private)
     // static
     static NAN_METHOD(New);
     static NAN_METHOD(getString);
     static NAN_METHOD(get);
-};
+VALUE_WRAPPER_TEMPLATE_END
 
 #endif //LLVM_NODE_CONSTANT_DATA_ARRAY_H

--- a/src/ir/constant-fp.cc
+++ b/src/ir/constant-fp.cc
@@ -58,10 +58,6 @@ NAN_GETTER(ConstantFPWrapper::getValueAPF) {
         info.GetReturnValue().Set(Nan::New(value.convertToDouble()));
 }
 
-llvm::ConstantFP *ConstantFPWrapper::getConstantFP() {
-    return static_cast<llvm::ConstantFP*>(getValue());
-}
-
 v8::Local<v8::Object> ConstantFPWrapper::of(llvm::ConstantFP *constantFP) {
     auto constructorFunction = Nan::GetFunction(Nan::New(constantFpTemplate())).ToLocalChecked();
     v8::Local<v8::Value> args[1] = { Nan::New<v8::External>(constantFP) };

--- a/src/ir/constant-fp.cc
+++ b/src/ir/constant-fp.cc
@@ -58,14 +58,7 @@ NAN_GETTER(ConstantFPWrapper::getValueAPF) {
         info.GetReturnValue().Set(Nan::New(value.convertToDouble()));
 }
 
-v8::Local<v8::Object> ConstantFPWrapper::of(llvm::ConstantFP *constantFP) {
-    auto constructorFunction = Nan::GetFunction(Nan::New(constantFpTemplate())).ToLocalChecked();
-    v8::Local<v8::Value> args[1] = { Nan::New<v8::External>(constantFP) };
-    auto instance = Nan::NewInstance(constructorFunction, 1, args).ToLocalChecked();
-
-    Nan::EscapableHandleScope escapeScpoe {};
-    return escapeScpoe.Escape(instance);
-}
+VALUE_WRAPPER_OF_DEFINITION(ConstantFP, ConstantFP, constantFp)
 
 Nan::Persistent<v8::FunctionTemplate>& ConstantFPWrapper::constantFpTemplate() {
     static Nan::Persistent<v8::FunctionTemplate> functionTemplate {};

--- a/src/ir/constant-fp.h
+++ b/src/ir/constant-fp.h
@@ -5,25 +5,11 @@
 #ifndef LLVM_NODE_CONSTANT_FP_WRAPPER_H
 #define LLVM_NODE_CONSTANT_FP_WRAPPER_H
 
-#include <nan.h>
 #include <llvm/IR/Constants.h>
 #include "constant.h"
-#include "../util/from-value-mixin.h"
+#include "value-wrapper-template.h"
 
-class ConstantFPWrapper: public ConstantWrapper, public FromValueMixin<ConstantFPWrapper> {
-public:
-    static NAN_MODULE_INIT(Init);
-    static v8::Local<v8::Object> of(llvm::ConstantFP* constantFP);
-    using FromValueMixin<ConstantFPWrapper>::FromValue;
-    llvm::ConstantFP* getConstantFP();
-
-private:
-    explicit ConstantFPWrapper(llvm::ConstantFP* constant)
-            : ConstantWrapper { constant }
-    {}
-
-    static Nan::Persistent<v8::FunctionTemplate>& constantFpTemplate();
-
+VALUE_WRAPPER_TEMPLATE_BEGIN(ConstantFP, ConstantFP, constantFp, Constant, private)
     // static
     static NAN_METHOD(New);
     static NAN_METHOD(get);
@@ -31,6 +17,6 @@ private:
 
     // instance
     static NAN_GETTER(getValueAPF);
-};
+VALUE_WRAPPER_TEMPLATE_END
 
 #endif //LLVM_NODE_CONSTANT_FP_WRAPPER_H

--- a/src/ir/constant-int.cc
+++ b/src/ir/constant-int.cc
@@ -81,10 +81,6 @@ NAN_GETTER(ConstantIntWrapper::getValueApf) {
     info.GetReturnValue().Set(Nan::New(value.signedRoundToDouble()));
 }
 
-llvm::ConstantInt *ConstantIntWrapper::getConstantInt() {
-    return static_cast<llvm::ConstantInt*>(getValue());
-}
-
 v8::Local<v8::Object> ConstantIntWrapper::of(llvm::ConstantInt *constantInt) {
     auto constructorFunction = Nan::GetFunction(Nan::New(constantIntTemplate())).ToLocalChecked();
     v8::Local<v8::Value> args[1] = { Nan::New<v8::External>(constantInt) };

--- a/src/ir/constant-int.cc
+++ b/src/ir/constant-int.cc
@@ -81,14 +81,7 @@ NAN_GETTER(ConstantIntWrapper::getValueApf) {
     info.GetReturnValue().Set(Nan::New(value.signedRoundToDouble()));
 }
 
-v8::Local<v8::Object> ConstantIntWrapper::of(llvm::ConstantInt *constantInt) {
-    auto constructorFunction = Nan::GetFunction(Nan::New(constantIntTemplate())).ToLocalChecked();
-    v8::Local<v8::Value> args[1] = { Nan::New<v8::External>(constantInt) };
-    auto instance = Nan::NewInstance(constructorFunction, 1, args).ToLocalChecked();
-
-    Nan::EscapableHandleScope escapeScpoe {};
-    return escapeScpoe.Escape(instance);
-}
+VALUE_WRAPPER_OF_DEFINITION(ConstantInt, ConstantInt, constantInt)
 
 Nan::Persistent<v8::FunctionTemplate>& ConstantIntWrapper::constantIntTemplate() {
     static Nan::Persistent<v8::FunctionTemplate> functionTemplate {};

--- a/src/ir/constant-int.h
+++ b/src/ir/constant-int.h
@@ -5,24 +5,11 @@
 #ifndef LLVM_NODE_CONSTANT_INT_H
 #define LLVM_NODE_CONSTANT_INT_H
 
-#include <nan.h>
 #include <llvm/IR/Constants.h>
 #include "constant.h"
+#include "value-wrapper-template.h"
 
-class ConstantIntWrapper: public ConstantWrapper, public FromValueMixin<ConstantIntWrapper> {
-public:
-    static NAN_MODULE_INIT(Init);
-    static v8::Local<v8::Object> of(llvm::ConstantInt* constantInt);
-    using FromValueMixin<ConstantIntWrapper>::FromValue;
-    llvm::ConstantInt* getConstantInt();
-
-private:
-    explicit ConstantIntWrapper(llvm::ConstantInt* constant)
-            : ConstantWrapper { constant }
-    {}
-
-    static Nan::Persistent<v8::FunctionTemplate>& constantIntTemplate();
-
+VALUE_WRAPPER_TEMPLATE_BEGIN(ConstantInt, ConstantInt, constantInt, Constant, private)
     // static
     static NAN_METHOD(New);
     static NAN_METHOD(get);
@@ -31,6 +18,6 @@ private:
 
     // instance
     static NAN_GETTER(getValueApf);
-};
+VALUE_WRAPPER_TEMPLATE_END
 
 #endif //LLVM_NODE_CONSTANT_INT_H

--- a/src/ir/constant-pointer-null.cc
+++ b/src/ir/constant-pointer-null.cc
@@ -37,10 +37,6 @@ NAN_METHOD(ConstantPointerNullWrapper::get) {
     info.GetReturnValue().Set(ConstantPointerNullWrapper::of(constant));
 }
 
-llvm::ConstantPointerNull *ConstantPointerNullWrapper::getConstantPointerNull() {
-    return static_cast<llvm::ConstantPointerNull*>(getValue());
-}
-
 v8::Local<v8::Object> ConstantPointerNullWrapper::of(llvm::ConstantPointerNull *constantPointerNull) {
     auto constructorFunction = Nan::GetFunction(Nan::New(constantPointerNullTemplate())).ToLocalChecked();
     v8::Local<v8::Value> args[1] = { Nan::New<v8::External>(constantPointerNull) };

--- a/src/ir/constant-pointer-null.cc
+++ b/src/ir/constant-pointer-null.cc
@@ -37,14 +37,7 @@ NAN_METHOD(ConstantPointerNullWrapper::get) {
     info.GetReturnValue().Set(ConstantPointerNullWrapper::of(constant));
 }
 
-v8::Local<v8::Object> ConstantPointerNullWrapper::of(llvm::ConstantPointerNull *constantPointerNull) {
-    auto constructorFunction = Nan::GetFunction(Nan::New(constantPointerNullTemplate())).ToLocalChecked();
-    v8::Local<v8::Value> args[1] = { Nan::New<v8::External>(constantPointerNull) };
-    auto instance = Nan::NewInstance(constructorFunction, 1, args).ToLocalChecked();
-
-    Nan::EscapableHandleScope escapeScpoe {};
-    return escapeScpoe.Escape(instance);
-}
+VALUE_WRAPPER_OF_DEFINITION(ConstantPointerNull, ConstantPointerNull, constantPointerNull)
 
 Nan::Persistent<v8::FunctionTemplate>& ConstantPointerNullWrapper::constantPointerNullTemplate() {
     static Nan::Persistent<v8::FunctionTemplate> functionTemplate {};

--- a/src/ir/constant-pointer-null.h
+++ b/src/ir/constant-pointer-null.h
@@ -5,28 +5,14 @@
 #ifndef LLVM_NODE_CONSTANT_NULL_POINTER_H
 #define LLVM_NODE_CONSTANT_NULL_POINTER_H
 
-#include <nan.h>
 #include <llvm/IR/Constants.h>
 #include "constant.h"
-#include "../util/from-value-mixin.h"
+#include "value-wrapper-template.h"
 
-class ConstantPointerNullWrapper: public ConstantWrapper, public FromValueMixin<ConstantPointerNullWrapper> {
-public:
-    static NAN_MODULE_INIT(Init);
-    static v8::Local<v8::Object> of(llvm::ConstantPointerNull* constantPointerNull);
-    using FromValueMixin<ConstantPointerNullWrapper>::FromValue;
-    llvm::ConstantPointerNull* getConstantPointerNull();
-
-private:
-    explicit ConstantPointerNullWrapper(llvm::ConstantPointerNull* constant)
-            : ConstantWrapper { constant }
-    {}
-
-    static Nan::Persistent<v8::FunctionTemplate>& constantPointerNullTemplate();
-
+VALUE_WRAPPER_TEMPLATE_BEGIN(ConstantPointerNull, ConstantPointerNull, constantPointerNull, Constant, private)
     // static
     static NAN_METHOD(New);
     static NAN_METHOD(get);
-};
+VALUE_WRAPPER_TEMPLATE_END
 
 #endif //LLVM_NODE_CONSTANT_NULL_POINTER_H

--- a/src/ir/constant-struct.cc
+++ b/src/ir/constant-struct.cc
@@ -11,15 +11,7 @@ NAN_MODULE_INIT(ConstantStructWrapper::Init) {
     Nan::Set(target, Nan::New("ConstantStruct").ToLocalChecked(), constantStruct);
 }
 
-v8::Local<v8::Object> ConstantStructWrapper::of(llvm::ConstantStruct* constantStruct) {
-    auto constructor = Nan::GetFunction(Nan::New(constantStructTemplate())).ToLocalChecked();
-    v8::Local<v8::Value> args[1] = { Nan::New<v8::External> (constantStruct) };
-
-    auto instance = Nan::NewInstance(constructor, 1, args).ToLocalChecked();
-
-    Nan::EscapableHandleScope escapableHandleScope {};
-    return escapableHandleScope.Escape(instance);
-}
+VALUE_WRAPPER_OF_DEFINITION(ConstantStruct, ConstantStruct, constantStruct)
 
 Nan::Persistent<v8::FunctionTemplate>& ConstantStructWrapper::constantStructTemplate() {
     static Nan::Persistent<v8::FunctionTemplate> functionTemplate {};

--- a/src/ir/constant-struct.cc
+++ b/src/ir/constant-struct.cc
@@ -21,10 +21,6 @@ v8::Local<v8::Object> ConstantStructWrapper::of(llvm::ConstantStruct* constantSt
     return escapableHandleScope.Escape(instance);
 }
 
-llvm::ConstantStruct* ConstantStructWrapper::getConstantStruct() {
-    return static_cast<llvm::ConstantStruct*>(getValue());
-}
-
 Nan::Persistent<v8::FunctionTemplate>& ConstantStructWrapper::constantStructTemplate() {
     static Nan::Persistent<v8::FunctionTemplate> functionTemplate {};
 

--- a/src/ir/constant-struct.h
+++ b/src/ir/constant-struct.h
@@ -5,25 +5,13 @@
 #ifndef LLVM_NODE_CONSTANT_STRUCT_H
 #define LLVM_NODE_CONSTANT_STRUCT_H
 
-#include <nan.h>
 #include <llvm/IR/Constants.h>
 #include "constant.h"
+#include "value-wrapper-template.h"
 
-class ConstantStructWrapper: public ConstantWrapper, public FromValueMixin<ConstantStructWrapper> {
-public:
-    static NAN_MODULE_INIT(Init);
-    static v8::Local<v8::Object> of(llvm::ConstantStruct* constantStruct);
-    using FromValueMixin<ConstantStructWrapper>::FromValue;
-    llvm::ConstantStruct* getConstantStruct();
-
-private:
-    explicit ConstantStructWrapper(llvm::ConstantStruct* constantStruct) : ConstantWrapper { constantStruct }
-    {}
-
-    static Nan::Persistent<v8::FunctionTemplate>& constantStructTemplate();
-
+VALUE_WRAPPER_TEMPLATE_BEGIN(ConstantStruct, ConstantStruct, constantStruct, Constant, private)
     static NAN_METHOD(New);
     static NAN_METHOD(get);
-};
+VALUE_WRAPPER_TEMPLATE_END
 
 #endif //LLVM_NODE_CONSTANT_STRUCT_H

--- a/src/ir/constant.cc
+++ b/src/ir/constant.cc
@@ -127,7 +127,3 @@ Nan::Persistent<v8::FunctionTemplate>& ConstantWrapper::constantTemplate() {
 
     return functionTemplate;
 }
-
-llvm::Constant *ConstantWrapper::getConstant() {
-    return static_cast<llvm::Constant*>(getValue());
-}

--- a/src/ir/constant.h
+++ b/src/ir/constant.h
@@ -5,26 +5,10 @@
 #ifndef LLVM_NODE_CONSTANTFPWRAPPER_H
 #define LLVM_NODE_CONSTANTFPWRAPPER_H
 
-#include <nan.h>
 #include <llvm/IR/Constants.h>
-#include "value.h"
-#include "../util/from-value-mixin.h"
+#include "value-wrapper-template.h"
 
-class ConstantWrapper: public ValueWrapper, public FromValueMixin<ConstantWrapper> {
-public:
-    static NAN_MODULE_INIT(Init);
-    static v8::Local<v8::Object> of(llvm::Constant* constant);
-    using FromValueMixin<ConstantWrapper>::FromValue;
-    llvm::Constant* getConstant();
-
-protected:
-    static Nan::Persistent<v8::FunctionTemplate>& constantTemplate();
-    explicit ConstantWrapper(llvm::Constant *constant)
-            : ValueWrapper {constant }
-    {}
-
-private:
-
+VALUE_WRAPPER_TEMPLATE_BEGIN(Constant, Constant, constant, Value, protected)
     // static
     static NAN_METHOD(New);
     static NAN_METHOD(getNullValue);
@@ -34,6 +18,6 @@ private:
     static NAN_METHOD(isNullValue);
     static NAN_METHOD(isOneValue);
     static NAN_METHOD(isAllOnesValue);
-};
+VALUE_WRAPPER_TEMPLATE_END
 
 #endif //LLVM_NODE_CONSTANTFPWRAPPER_H

--- a/src/ir/function.cc
+++ b/src/ir/function.cc
@@ -9,8 +9,6 @@
 #include "argument.h"
 #include "basic-block.h"
 
-FunctionWrapper::FunctionWrapper(llvm::Function *function) : ConstantWrapper { function } {}
-
 NAN_MODULE_INIT(FunctionWrapper::Init) {
     auto constructorFunction = Nan::GetFunction(Nan::New(functionTemplate())).ToLocalChecked();
     Nan::Set(target, Nan::New("Function").ToLocalChecked(), constructorFunction);
@@ -231,10 +229,6 @@ NAN_SETTER(FunctionWrapper::setVisibility) {
 
 NAN_METHOD(FunctionWrapper::viewCFG) {
     FunctionWrapper::FromValue(info.Holder())->getFunction()->viewCFG();
-}
-
-llvm::Function *FunctionWrapper::getFunction() {
-    return static_cast<llvm::Function*>(getValue());
 }
 
 bool FunctionWrapper::isInstance(v8::Local<v8::Value> value) {

--- a/src/ir/function.cc
+++ b/src/ir/function.cc
@@ -60,17 +60,7 @@ Nan::Persistent<v8::FunctionTemplate> &FunctionWrapper::functionTemplate() {
     return tmpl;
 }
 
-v8::Local<v8::Object> FunctionWrapper::of(llvm::Function *function) {
-    v8::Local<v8::FunctionTemplate> localTemplate = Nan::New(functionTemplate());
-    v8::Local<v8::Function> constructor = Nan::GetFunction(localTemplate).ToLocalChecked();
-
-    v8::Local<v8::Value> args[1] = { Nan::New<v8::External>(function) };
-
-    v8::Local<v8::Object> instance = Nan::NewInstance(constructor, 1, args ).ToLocalChecked();
-
-    Nan::EscapableHandleScope escapeScope {};
-    return escapeScope.Escape(instance);
-}
+VALUE_WRAPPER_OF_DEFINITION(Function, Function, function)
 
 NAN_METHOD(FunctionWrapper::Create) {
     if (info.Length() < 2 || !FunctionTypeWrapper::isInstance(info[0]) || !info[1]->IsUint32()

--- a/src/ir/function.h
+++ b/src/ir/function.h
@@ -5,24 +5,11 @@
 #ifndef LLVM_NODE_FUNCTION_H
 #define LLVM_NODE_FUNCTION_H
 
-#include <nan.h>
 #include <llvm/IR/Function.h>
 #include "constant.h"
-#include "../util/from-value-mixin.h"
+#include "value-wrapper-template.h"
 
-class FunctionWrapper: public ConstantWrapper, public FromValueMixin<FunctionWrapper> {
-public:
-    static NAN_MODULE_INIT(Init);
-    static v8::Local<v8::Object> of(llvm::Function* function);
-
-    llvm::Function* getFunction();
-
-    static bool isInstance(v8::Local<v8::Value> value);
-    using FromValueMixin<FunctionWrapper>::FromValue;
-
-private:
-    explicit FunctionWrapper(llvm::Function* function);
-
+VALUE_WRAPPER_TEMPLATE_BEGIN(Function, Function, function, Constant, private)
     // static
     static NAN_METHOD(New);
     static NAN_METHOD(Create);
@@ -42,8 +29,8 @@ private:
     static NAN_SETTER(setVisibility);
     static NAN_METHOD(viewCFG);
 
-    static Nan::Persistent<v8::FunctionTemplate>& functionTemplate();
-};
-
+public:
+    static bool isInstance(v8::Local<v8::Value> value);
+VALUE_WRAPPER_TEMPLATE_END
 
 #endif //LLVM_NODE_FUNCTION_H

--- a/src/ir/global-variable.cc
+++ b/src/ir/global-variable.cc
@@ -12,14 +12,7 @@ NAN_MODULE_INIT(GlobalVariableWrapper::Init) {
     Nan::Set(target, Nan::New("GlobalVariable").ToLocalChecked(), globalVariable);
 }
 
-v8::Local<v8::Object> GlobalVariableWrapper::of(llvm::GlobalVariable* variable) {
-    auto constructor = Nan::GetFunction(Nan::New(globalVariableTemplate())).ToLocalChecked();
-    v8::Local<v8::Value> args[1] = { Nan::New<v8::External> (variable) };
-
-    auto instance = Nan::NewInstance(constructor, 1, args).ToLocalChecked();
-    Nan::EscapableHandleScope escapeHandleScope {};
-    return escapeHandleScope.Escape(instance);
-}
+VALUE_WRAPPER_OF_DEFINITION(GlobalVariable, GlobalVariable, globalVariable)
 
 NAN_METHOD(GlobalVariableWrapper::New) {
     if (!info.IsConstructCall()) {

--- a/src/ir/global-variable.cc
+++ b/src/ir/global-variable.cc
@@ -21,10 +21,6 @@ v8::Local<v8::Object> GlobalVariableWrapper::of(llvm::GlobalVariable* variable) 
     return escapeHandleScope.Escape(instance);
 }
 
-llvm::GlobalVariable* GlobalVariableWrapper::getGlobalVariable() {
-    return static_cast<llvm::GlobalVariable*>(getValue());
-}
-
 NAN_METHOD(GlobalVariableWrapper::New) {
     if (!info.IsConstructCall()) {
         return Nan::ThrowTypeError("The GlobalVariable needs to be called with new");

--- a/src/ir/global-variable.h
+++ b/src/ir/global-variable.h
@@ -5,23 +5,11 @@
 #ifndef LLVM_NODE_GLOBAL_VARIABLE_H
 #define LLVM_NODE_GLOBAL_VARIABLE_H
 
-#include <nan.h>
 #include <llvm/IR/GlobalVariable.h>
 #include "constant.h"
-#include "../util/from-value-mixin.h"
+#include "value-wrapper-template.h"
 
-class GlobalVariableWrapper: public ConstantWrapper, public FromValueMixin<GlobalVariableWrapper> {
-public:
-
-    static NAN_MODULE_INIT(Init);
-    static v8::Local<v8::Object> of(llvm::GlobalVariable* variable);
-    using FromValueMixin<GlobalVariableWrapper>::FromValue;
-    llvm::GlobalVariable* getGlobalVariable();
-
-
-private:
-    explicit GlobalVariableWrapper(llvm::GlobalVariable* variable) : ConstantWrapper { variable } {}
-
+VALUE_WRAPPER_TEMPLATE_BEGIN(GlobalVariable, GlobalVariable, globalVariable, Constant, private)
     static NAN_METHOD(New);
     static NAN_METHOD(NewFromExternal);
     static NAN_METHOD(NewFromArguments);
@@ -34,8 +22,6 @@ private:
 
     static NAN_GETTER(getInitializer);
     static NAN_SETTER(setInitializer);
-    static Nan::Persistent<v8::FunctionTemplate>& globalVariableTemplate();
-
-};
+VALUE_WRAPPER_TEMPLATE_END
 
 #endif //LLVM_NODE_GLOBAL_VARIABLE_H

--- a/src/ir/phi-node.cc
+++ b/src/ir/phi-node.cc
@@ -5,10 +5,6 @@
 #include "phi-node.h"
 #include "basic-block.h"
 
-llvm::PHINode *PhiNodeWrapper::getPhiNode() {
-    return static_cast<llvm::PHINode*>(getValue());
-}
-
 v8::Local<v8::Object> PhiNodeWrapper::of(llvm::PHINode *phiNode) {
     auto constructorFunction = Nan::GetFunction(Nan::New(phiNodeTemplate())).ToLocalChecked();
     v8::Local<v8::Value> args[1] = { Nan::New<v8::External>(phiNode) };
@@ -54,4 +50,9 @@ NAN_METHOD(PhiNodeWrapper::addIncoming) {
     auto* basicBlock = BasicBlockWrapper::FromValue(info[1])->getBasicBlock();
 
     PhiNodeWrapper::FromValue(info.Holder())->getPhiNode()->addIncoming(value, basicBlock);
+}
+
+Nan::Persistent<v8::FunctionTemplate>& PhiNodeWrapper::phiNodeTemplate() {
+    static Nan::Persistent<v8::FunctionTemplate> functionTemplate {};
+    return functionTemplate;
 }

--- a/src/ir/phi-node.cc
+++ b/src/ir/phi-node.cc
@@ -5,14 +5,7 @@
 #include "phi-node.h"
 #include "basic-block.h"
 
-v8::Local<v8::Object> PhiNodeWrapper::of(llvm::PHINode *phiNode) {
-    auto constructorFunction = Nan::GetFunction(Nan::New(phiNodeTemplate())).ToLocalChecked();
-    v8::Local<v8::Value> args[1] = { Nan::New<v8::External>(phiNode) };
-    auto instance = Nan::NewInstance(constructorFunction, 1, args).ToLocalChecked();
-
-    Nan::EscapableHandleScope escapeScope {};
-    return escapeScope.Escape(instance);
-}
+VALUE_WRAPPER_OF_DEFINITION(PHINode, PhiNode, phiNode)
 
 NAN_MODULE_INIT(PhiNodeWrapper::Init) {
     auto functionTemplate = Nan::New<v8::FunctionTemplate>(PhiNodeWrapper::New);

--- a/src/ir/phi-node.h
+++ b/src/ir/phi-node.h
@@ -5,31 +5,12 @@
 #ifndef LLVM_NODE_PHINODEWRAPPER_H
 #define LLVM_NODE_PHINODEWRAPPER_H
 
-#include<nan.h>
-#include<llvm/IR/Instructions.h>
-#include "value.h"
+#include <llvm/IR/Instructions.h>
+#include "value-wrapper-template.h"
 
-class PhiNodeWrapper: public ValueWrapper, public FromValueMixin<PhiNodeWrapper> {
-public:
-    llvm::PHINode* getPhiNode();
-
-    static NAN_MODULE_INIT(Init);
-    static v8::Local<v8::Object> of(llvm::PHINode* phiNode);
-    using FromValueMixin<PhiNodeWrapper>::FromValue;
-
-private:
-    explicit PhiNodeWrapper(llvm::PHINode* phiNode)
-            : ValueWrapper { phiNode }
-    {}
-
+VALUE_WRAPPER_TEMPLATE_BEGIN(PHINode, PhiNode, phiNode, Value, private)
     static NAN_METHOD(New);
     static NAN_METHOD(addIncoming);
-
-    static inline Nan::Persistent<v8::FunctionTemplate>& phiNodeTemplate() {
-        static Nan::Persistent<v8::FunctionTemplate> functionTemplate {};
-        return functionTemplate;
-    }
-};
-
+VALUE_WRAPPER_TEMPLATE_END
 
 #endif //LLVM_NODE_PHINODEWRAPPER_H

--- a/src/ir/undef-value.cc
+++ b/src/ir/undef-value.cc
@@ -37,10 +37,6 @@ NAN_METHOD(UndefValueWrapper::get) {
     info.GetReturnValue().Set(UndefValueWrapper::of(undefValue));
 }
 
-llvm::UndefValue* UndefValueWrapper::getUndefValue() {
-    return static_cast<llvm::UndefValue*>(getValue());
-}
-
 v8::Local<v8::Object> UndefValueWrapper::of(llvm::UndefValue* undefValue) {
     auto constructorFunction = Nan::GetFunction(Nan::New(undefValueTemplate())).ToLocalChecked();
     v8::Local<v8::Value> args[1] = { Nan::New<v8::External>(undefValue) };

--- a/src/ir/undef-value.cc
+++ b/src/ir/undef-value.cc
@@ -37,14 +37,7 @@ NAN_METHOD(UndefValueWrapper::get) {
     info.GetReturnValue().Set(UndefValueWrapper::of(undefValue));
 }
 
-v8::Local<v8::Object> UndefValueWrapper::of(llvm::UndefValue* undefValue) {
-    auto constructorFunction = Nan::GetFunction(Nan::New(undefValueTemplate())).ToLocalChecked();
-    v8::Local<v8::Value> args[1] = { Nan::New<v8::External>(undefValue) };
-    auto instance = Nan::NewInstance(constructorFunction, 1, args).ToLocalChecked();
-
-    Nan::EscapableHandleScope escapeScpoe {};
-    return escapeScpoe.Escape(instance);
-}
+VALUE_WRAPPER_OF_DEFINITION(UndefValue, UndefValue, undefValue)
 
 Nan::Persistent<v8::FunctionTemplate>& UndefValueWrapper::undefValueTemplate() {
     static Nan::Persistent<v8::FunctionTemplate> functionTemplate {};

--- a/src/ir/undef-value.h
+++ b/src/ir/undef-value.h
@@ -5,27 +5,14 @@
 #ifndef LLVM_NODE_UNDEF_VALUE_H
 #define LLVM_NODE_UNDEF_VALUE_H
 
-#include <nan.h>
 #include <llvm/IR/Constants.h>
 #include "constant.h"
+#include "value-wrapper-template.h"
 
-class UndefValueWrapper: public ConstantWrapper, public FromValueMixin<UndefValueWrapper> {
-public:
-    static NAN_MODULE_INIT(Init);
-    static v8::Local<v8::Object> of(llvm::UndefValue* undefValue);
-    using FromValueMixin<UndefValueWrapper>::FromValue;
-    llvm::UndefValue* getUndefValue();
-
-private:
-    explicit UndefValueWrapper(llvm::UndefValue* constant)
-            : ConstantWrapper { constant }
-    {}
-
-    static Nan::Persistent<v8::FunctionTemplate>& undefValueTemplate();
-
+VALUE_WRAPPER_TEMPLATE_BEGIN(UndefValue, UndefValue, undefValue, Constant, private)
     // static
     static NAN_METHOD(New);
     static NAN_METHOD(get);
-};
+VALUE_WRAPPER_TEMPLATE_END
 
 #endif //LLVM_NODE_UNDEF_VALUE_H

--- a/src/ir/value-wrapper-template.h
+++ b/src/ir/value-wrapper-template.h
@@ -23,4 +23,13 @@ private:                                                                        
 
 #define VALUE_WRAPPER_TEMPLATE_END };
 
+#define VALUE_WRAPPER_OF_DEFINITION(LLVM_NAME, NAME, NAME_LOWERCASE)                                            \
+v8::Local<v8::Object> NAME##Wrapper::of(llvm::LLVM_NAME* value) {                                               \
+    auto constructorFunction = Nan::GetFunction(Nan::New(NAME_LOWERCASE##Template())).ToLocalChecked();         \
+    v8::Local<v8::Value> args[1] = { Nan::New<v8::External>(value) };                                           \
+    auto instance = Nan::NewInstance(constructorFunction, 1, args).ToLocalChecked();                            \
+    Nan::EscapableHandleScope escapeScope {};                                                                   \
+    return escapeScope.Escape(instance);                                                                        \
+}
+
 #endif

--- a/src/ir/value-wrapper-template.h
+++ b/src/ir/value-wrapper-template.h
@@ -1,0 +1,26 @@
+#ifndef LLVM_NODE_VALUE_WRAPPER_TEMPLATE_H
+#define LLVM_NODE_VALUE_WRAPPER_TEMPLATE_H
+
+#include <nan.h>
+#include "value.h"
+#include "../util/from-value-mixin.h"
+
+#define VALUE_WRAPPER_TEMPLATE_BEGIN(LLVM_NAME, NAME, NAME_LOWERCASE, BASE_CLASS, CONSTRUCTOR_ACCESS_SPECIFIER) \
+class NAME##Wrapper: public BASE_CLASS##Wrapper, public FromValueMixin<NAME##Wrapper> {                         \
+public:                                                                                                         \
+    using FromValueMixin<NAME##Wrapper>::FromValue;                                                             \
+    static NAN_MODULE_INIT(Init);                                                                               \
+    static v8::Local<v8::Object> of(llvm::LLVM_NAME* value);                                                    \
+    llvm::LLVM_NAME* get##NAME() {                                                                              \
+        return static_cast<llvm::LLVM_NAME*>(ValueWrapper::getValue());                                         \
+    }                                                                                                           \
+                                                                                                                \
+CONSTRUCTOR_ACCESS_SPECIFIER:                                                                                   \
+    explicit NAME##Wrapper(llvm::LLVM_NAME* value) : BASE_CLASS##Wrapper { value } {}                           \
+    static Nan::Persistent<v8::FunctionTemplate>& NAME_LOWERCASE##Template();                                   \
+                                                                                                                \
+private:                                                                                                        \
+
+#define VALUE_WRAPPER_TEMPLATE_END };
+
+#endif


### PR DESCRIPTION
While trying to add new features to this project I noticed that there's a lot of duplication in the codebase that IMO makes it a bit challenging to maintain and extend. I would like to start reducing this duplication, one way or another.

One possible end goal that I think would be nice at some point, would be to use some bindings generator that would generate the C++ headers and source files (and possibly even the TypeScript definition file) based on some interface definition format or using some templating language. But that's probably somewhere down the road. What's your opinion on this?

As for this PR, it's a step towards that direction by getting rid of some the duplication using macros. While macros are not the nicest thing, I think they're worth it for this use case, at least for now, considering how much duplication there is (and will be, when we add new functionality). 