### PR TITLE
Make package.json scripts work with both npm and yarn

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,10 +28,10 @@
   "scripts": {
     "configure": "cmake-js configure",
     "build": "cmake-js compile",
-    "install": "npm run build",
+    "install": "cmake-js compile",
     "clean": "cmake-js clean",
     "rebuild": "cmake-js rebuild",
-    "pretest": "yarn tsc llvm-node.d.ts --strict",
+    "pretest": "tsc llvm-node.d.ts --strict",
     "test": "jest --ci --coverage --runInBand",
     "test:watch": "jest --watchAll",
     "release:major": "changelog -M && git add CHANGELOG.md && git commit -m 'updated CHANGELOG.md' && npm version major && git push origin && git push origin --tags",


### PR DESCRIPTION
To avoid "npm: command not found" error when npm is not in PATH (e.g. when using nvm).