### PR TITLE
Fix type definition of Module.getFunction to include undefined

### DIFF
--- a/llvm-node.d.ts
+++ b/llvm-node.d.ts
@@ -652,7 +652,7 @@ declare namespace llvm {
 
     print(): string;
 
-    getFunction(name: string): Function;
+    getFunction(name: string): Function | undefined;
 
     getOrInsertFunction(name: string, functionType: FunctionType): Constant;
 


### PR DESCRIPTION
Returns undefined here:
https://github.com/MichaReiser/llvm-node/blob/1d505e718e07d843de43087f36791ab7f6e860a4/src/ir/module.cc#L78-L84

Test is already in place:
https://github.com/MichaReiser/llvm-node/blob/1d505e718e07d843de43087f36791ab7f6e860a4/test/ir/module.spec.ts#L134-L138