### PR TITLE
Include target triple in lookupTarget error message

### DIFF
--- a/src/support/target-registry.cc
+++ b/src/support/target-registry.cc
@@ -10,7 +10,7 @@ NAN_METHOD(TargetRegistryWrapper::lookupTarget) {
         const llvm::Target* result = llvm::TargetRegistry::lookupTarget(triple, error);
 
         if (!result) {
-            std::string msg = "Failed to lookup target: " + error;
+            std::string msg = "Failed to lookup target '" + triple + "': " + error;
             Nan::ThrowError(msg.c_str());
             return;
         }


### PR DESCRIPTION
Previously the error message was e.g. "Failed to lookup target: No available targets are compatible with this triple." I think this will be more helpful when it mentions what the target triple was.

Another possibility would be to pass the error message from LLVM unchanged, and let the user build a better error message themselves.