### PR TITLE
Feature: ConstantFP support getNegativeZero/getZeroValueForNegation

### DIFF
--- a/llvm-node.d.ts
+++ b/llvm-node.d.ts
@@ -176,6 +176,10 @@ declare namespace llvm {
   class ConstantFP extends Constant {
     static get(context: LLVMContext, value: number): ConstantFP;
 
+    static getZeroValueForNegation(type: Type): Constant;
+
+    static getNegativeZero(type: Type): Constant;
+
     static getNaN(type: Type): Constant;
 
     private constructor();

--- a/src/ir/constant-fp.cc
+++ b/src/ir/constant-fp.cc
@@ -51,6 +51,28 @@ NAN_METHOD(ConstantFPWrapper::getNaN) {
     info.GetReturnValue().Set(ConstantWrapper::of(nan));
 }
 
+NAN_METHOD(ConstantFPWrapper::getZeroValueForNegation) {
+    if (info.Length() != 1 || !TypeWrapper::isInstance(info[0])) {
+        return Nan::ThrowTypeError("getZeroValueForNegation needs to be called with: type: Type");
+    }
+
+    auto* type = TypeWrapper::FromValue(info[0])->getType();
+    llvm::Constant* zero = llvm::ConstantFP::getZeroValueForNegation(type);
+
+    info.GetReturnValue().Set(ConstantWrapper::of(zero));
+}
+
+NAN_METHOD(ConstantFPWrapper::getNegativeZero) {
+    if (info.Length() != 1 || !TypeWrapper::isInstance(info[0])) {
+        return Nan::ThrowTypeError("getNegativeZero needs to be called with: type: Type");
+    }
+
+    auto* type = TypeWrapper::FromValue(info[0])->getType();
+    llvm::Constant* zero = llvm::ConstantFP::getNegativeZero(type);
+
+    info.GetReturnValue().Set(ConstantWrapper::of(zero));
+}
+
 NAN_GETTER(ConstantFPWrapper::getValueAPF) {
         auto* wrapper = ConstantFPWrapper::FromValue(info.Holder());
         auto value = wrapper->getConstantFP()->getValueAPF();
@@ -81,6 +103,8 @@ Nan::Persistent<v8::FunctionTemplate>& ConstantFPWrapper::constantFpTemplate() {
         localTemplate->Inherit(Nan::New(constantTemplate()));
 
         Nan::SetMethod(localTemplate, "get", ConstantFPWrapper::get);
+        Nan::SetMethod(localTemplate, "getZeroValueForNegation", ConstantFPWrapper::getZeroValueForNegation);
+        Nan::SetMethod(localTemplate, "getNegativeZero", ConstantFPWrapper::getNegativeZero);
         Nan::SetMethod(localTemplate, "getNaN", ConstantFPWrapper::getNaN);
         Nan::SetAccessor(localTemplate->InstanceTemplate(), Nan::New("value").ToLocalChecked(), ConstantFPWrapper::getValueAPF);
 

--- a/src/ir/constant-fp.h
+++ b/src/ir/constant-fp.h
@@ -27,6 +27,8 @@ private:
     // static
     static NAN_METHOD(New);
     static NAN_METHOD(get);
+    static NAN_METHOD(getZeroValueForNegation);
+    static NAN_METHOD(getNegativeZero);
     static NAN_METHOD(getNaN);
 
     // instance

--- a/test/ir/constant-fp.spec.ts
+++ b/test/ir/constant-fp.spec.ts
@@ -40,6 +40,24 @@ describe("ir/constant-fp", () => {
     });
   });
 
+  describe("getZeroValueForNegation", () => {
+    it("returns the zero value for negation", () => {
+      const nan = llvm.ConstantFP.getZeroValueForNegation(llvm.Type.getDoubleTy(context));
+
+      expect(nan).toBeDefined();
+      expect(nan).toBeInstanceOf(llvm.Constant);
+    });
+  });
+
+  describe("getNegativeZero", () => {
+    it("returns the negative zero value", () => {
+      const nan = llvm.ConstantFP.getNegativeZero(llvm.Type.getDoubleTy(context));
+
+      expect(nan).toBeDefined();
+      expect(nan).toBeInstanceOf(llvm.Constant);
+    });
+  });
+
   describe("getNaN", () => {
     it("returns the nan value", () => {
       const nan = llvm.ConstantFP.getNaN(llvm.Type.getDoubleTy(context));


### PR DESCRIPTION
Hey!

Adds the methods [`getNegativeZero`](http://llvm.org/doxygen/classllvm_1_1ConstantFP.html#aac74ea960aaa245b9ad883c03805997b) and [`getZeroValueForNegation`](http://llvm.org/doxygen/classllvm_1_1ConstantFP.html#ab4d218c572245abd0b1c895d603cba36) to `ConstantFP`.

Thanks