### PR TITLE
Fix LLVM 9 Build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,7 @@ language: node_js
 node_js:
   - "11"
   - "10"
-  - "9"
   - "8"
-  - "7"
   - "6"
 cache: yarn
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_install:
   - wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
   - echo $LLVM_DEB | sudo tee -a /etc/apt/sources.list
   - sudo apt-get update -qq
-  - sudo apt-get install libedit-dev llvm-$LLVM_VERSION llvm-$LLVM_VERSION-dev
+  - sudo apt-get install libedit-dev llvm-$LLVM_VERSION llvm-$LLVM_VERSION-dev clang-$LLVM_VERSION
   - npm config set cmake_LLVM_DIR $(llvm-config-$LLVM_VERSION --cmakedir)
 deploy:
   provider: npm

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_install:
   - wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
   - echo $LLVM_DEB | sudo tee -a /etc/apt/sources.list
   - sudo apt-get update -qq
-  - sudo apt-get install libedit-dev llvm-$LLVM_VERSION llvm-$LLVM_VERSION-dev clang-$LLVM_VERSION
+  - sudo apt-get install libedit-dev llvm-$LLVM_VERSION llvm-$LLVM_VERSION-dev clang-$LLVM_VERSION llvm-$LLVM_VERSION-tools
   - npm config set cmake_LLVM_DIR $(llvm-config-$LLVM_VERSION --cmakedir)
 deploy:
   provider: npm

--- a/llvm-node.d.ts
+++ b/llvm-node.d.ts
@@ -666,6 +666,11 @@ declare namespace llvm {
     private __marker: number;
   }
 
+  interface FunctionCallee {
+    callee: Value;
+    functionType: FunctionType;
+  }
+
   class Module {
     empty: boolean;
     readonly name: string;
@@ -682,7 +687,7 @@ declare namespace llvm {
 
     getFunction(name: string): Function | undefined;
 
-    getOrInsertFunction(name: string, functionType: FunctionType): Constant;
+    getOrInsertFunction(name: string, functionType: FunctionType): FunctionCallee;
 
     getGlobalVariable(name: string, allowInternal?: boolean): GlobalVariable;
 

--- a/src/ir/module.cc
+++ b/src/ir/module.cc
@@ -100,8 +100,8 @@ NAN_METHOD(ModuleWrapper::getOrInsertFunction) {
         Nan::Set(functionCallee, Nan::New("functionType").ToLocalChecked(), FunctionTypeWrapper::of(fnType));
     #else 
         auto llvmCallee = module->getOrInsertFunction(name, fnType);
-        Nan::Set(functionCallee, Nan::New("callee").ToLocalChecked(), ValueWrapper::of(llvmCallee->getCallee()));
-        Nan::Set(functionCallee, Nan::New("functionType").ToLocalChecked(), FunctionTypeWrapper::of(llvmCallee->getFunctionType()));
+        Nan::Set(functionCallee, Nan::New("callee").ToLocalChecked(), ValueWrapper::of(llvmCallee.getCallee()));
+        Nan::Set(functionCallee, Nan::New("functionType").ToLocalChecked(), FunctionTypeWrapper::of(llvmCallee.getFunctionType()));
     #endif
     
     Nan::EscapableHandleScope scope {};

--- a/src/ir/module.cc
+++ b/src/ir/module.cc
@@ -93,7 +93,19 @@ NAN_METHOD(ModuleWrapper::getOrInsertFunction) {
     std::string name = ToString(info[0]);
     auto* fnType = FunctionTypeWrapper::FromValue(info[1])->getFunctionType();
 
-    info.GetReturnValue().Set(ConstantWrapper::of(module->getOrInsertFunction(name, fnType)));
+    auto functionCallee = Nan::New<v8::Object>();
+
+    #if LLVM_VERSION_MAJOR < 9
+        Nan::Set(functionCallee, Nan::New("callee").ToLocalChecked(), ConstantWrapper::of(module->getOrInsertFunction(name, fnType)));
+        Nan::Set(functionCallee, Nan::New("functionType").ToLocalChecked(), FunctionTypeWrapper::of(fnType));
+    #else 
+        auto llvmCallee = module->getOrInsertFunction(name, fnType);
+        Nan::Set(functionCallee, Nan::New("callee").ToLocalChecked(), ValueWrapper::of(llvmCallee->getCallee()));
+        Nan::Set(functionCallee, Nan::New("functionType").ToLocalChecked(), FunctionTypeWrapper::of(llvmCallee->getFunctionType()));
+    #endif
+    
+    Nan::EscapableHandleScope scope {};
+    info.GetReturnValue().Set(scope.Escape(functionCallee));
 }
 
 NAN_METHOD(ModuleWrapper::getGlobalVariable) {


### PR DESCRIPTION
Fixes the llvm 9 travis build

- FileCheck is not installed
- Signature of `Module.getOrInsertFunction` changed to return a FunctionCallee instead of a `Constant`.

