### PR TITLE
Add Atomic Operations

### DIFF
--- a/llvm-node.d.ts
+++ b/llvm-node.d.ts
@@ -683,9 +683,7 @@ declare namespace llvm {
       Max,
       Min,
       UMax,
-      UMin,
-      FAdd,
-      FSub
+      UMin
     }
   }
 

--- a/llvm-node.d.ts
+++ b/llvm-node.d.ts
@@ -98,6 +98,16 @@ declare namespace llvm {
     Protected
   }
 
+  enum AtomicOrdering {
+    NotAtomic,
+    Unordered,
+    Monotonic,
+    Acquire,
+    Release,
+    AcquireRelease,
+    SequentiallyConsistent
+  }
+
   class Value {
     static MaxAlignmentExponent: number;
     static MaximumAlignment: number;
@@ -536,6 +546,8 @@ declare namespace llvm {
 
     createAShr(lhs: Value, rhs: Value, name?: string): Value;
 
+    createAtomicRMW(op: AtomicRMWInst.BinOp, ptr: Value, value: Value, ordering: AtomicOrdering): Value;
+
     createBitCast(value: Value, destType: Type, name?: string): Value;
 
     createBr(basicBlock: BasicBlock): Value;
@@ -658,6 +670,23 @@ declare namespace llvm {
     createZExt(value: Value, destType: Type, name?: string): Value;
 
     getInsertBlock(): BasicBlock | undefined;
+  }
+
+  namespace AtomicRMWInst {
+    enum BinOp {
+      Add,
+      Sub,
+      And,
+      Nand,
+      Or,
+      Xor,
+      Max,
+      Min,
+      UMax,
+      UMin,
+      FAdd,
+      FSub
+    }
   }
 
   class LLVMContext {

--- a/src/ir/atomic-rmw-inst.cc
+++ b/src/ir/atomic-rmw-inst.cc
@@ -15,8 +15,6 @@ NAN_MODULE_INIT(InitAtomicRMWInst) {
     Nan::Set(binOp, Nan::New("Min").ToLocalChecked(), Nan::New(static_cast<uint32_t>(llvm::AtomicRMWInst::BinOp::Min)));
     Nan::Set(binOp, Nan::New("UMax").ToLocalChecked(), Nan::New(static_cast<uint32_t>(llvm::AtomicRMWInst::BinOp::UMax)));
     Nan::Set(binOp, Nan::New("UMin").ToLocalChecked(), Nan::New(static_cast<uint32_t>(llvm::AtomicRMWInst::BinOp::UMin)));
-    Nan::Set(binOp, Nan::New("FAdd").ToLocalChecked(), Nan::New(static_cast<uint32_t>(llvm::AtomicRMWInst::BinOp::FAdd)));
-    Nan::Set(binOp, Nan::New("FSub").ToLocalChecked(), Nan::New(static_cast<uint32_t>(llvm::AtomicRMWInst::BinOp::FSub)));
 
     Nan::Set(atomicRMWInst, Nan::New("BinOp").ToLocalChecked(), binOp);
 

--- a/src/ir/atomic-rmw-inst.cc
+++ b/src/ir/atomic-rmw-inst.cc
@@ -1,0 +1,24 @@
+#include <llvm/IR/Instructions.h>
+#include "atomic-rmw-inst.h"
+
+NAN_MODULE_INIT(InitAtomicRMWInst) {
+    auto atomicRMWInst = Nan::New<v8::Object>();
+
+    auto binOp = Nan::New<v8::Object>();
+    Nan::Set(binOp, Nan::New("Add").ToLocalChecked(), Nan::New(static_cast<uint32_t>(llvm::AtomicRMWInst::BinOp::Add)));
+    Nan::Set(binOp, Nan::New("Sub").ToLocalChecked(), Nan::New(static_cast<uint32_t>(llvm::AtomicRMWInst::BinOp::Sub)));
+    Nan::Set(binOp, Nan::New("And").ToLocalChecked(), Nan::New(static_cast<uint32_t>(llvm::AtomicRMWInst::BinOp::And)));
+    Nan::Set(binOp, Nan::New("Nand").ToLocalChecked(), Nan::New(static_cast<uint32_t>(llvm::AtomicRMWInst::BinOp::Nand)));
+    Nan::Set(binOp, Nan::New("Or").ToLocalChecked(), Nan::New(static_cast<uint32_t>(llvm::AtomicRMWInst::BinOp::Or)));
+    Nan::Set(binOp, Nan::New("Xor").ToLocalChecked(), Nan::New(static_cast<uint32_t>(llvm::AtomicRMWInst::BinOp::Xor)));
+    Nan::Set(binOp, Nan::New("Max").ToLocalChecked(), Nan::New(static_cast<uint32_t>(llvm::AtomicRMWInst::BinOp::Max)));
+    Nan::Set(binOp, Nan::New("Min").ToLocalChecked(), Nan::New(static_cast<uint32_t>(llvm::AtomicRMWInst::BinOp::Min)));
+    Nan::Set(binOp, Nan::New("UMax").ToLocalChecked(), Nan::New(static_cast<uint32_t>(llvm::AtomicRMWInst::BinOp::UMax)));
+    Nan::Set(binOp, Nan::New("UMin").ToLocalChecked(), Nan::New(static_cast<uint32_t>(llvm::AtomicRMWInst::BinOp::UMin)));
+    Nan::Set(binOp, Nan::New("FAdd").ToLocalChecked(), Nan::New(static_cast<uint32_t>(llvm::AtomicRMWInst::BinOp::FAdd)));
+    Nan::Set(binOp, Nan::New("FSub").ToLocalChecked(), Nan::New(static_cast<uint32_t>(llvm::AtomicRMWInst::BinOp::FSub)));
+
+    Nan::Set(atomicRMWInst, Nan::New("BinOp").ToLocalChecked(), binOp);
+
+    Nan::Set(target, Nan::New("AtomicRMWInst").ToLocalChecked(), atomicRMWInst);
+}

--- a/src/ir/atomic-rmw-inst.h
+++ b/src/ir/atomic-rmw-inst.h
@@ -1,0 +1,8 @@
+#ifndef LLVM_ATOMIC_RMW_INST_H
+#define LLVM_ATOMIC_RMW_INST_H
+
+#include <nan.h>
+
+NAN_MODULE_INIT(InitAtomicRMWInst);
+
+#endif //LLVM_ATOMIC_RMW_INST_H

--- a/src/ir/ir-builder.cc
+++ b/src/ir/ir-builder.cc
@@ -74,6 +74,7 @@ NAN_MODULE_INIT(IRBuilderWrapper::Init) {
     Nan::SetPrototypeMethod(functionTemplate, "createAlignedStore", IRBuilderWrapper::CreateAlignedStore);
     Nan::SetPrototypeMethod(functionTemplate, "createAnd", &NANBinaryOperation<&ToBinaryOp<&llvm::IRBuilder<>::CreateAnd>>);
     Nan::SetPrototypeMethod(functionTemplate, "createAShr", &NANBinaryOperation<&ToBinaryOp<&llvm::IRBuilder<>::CreateAShr>>);
+    Nan::SetPrototypeMethod(functionTemplate, "createAtomicRMW", IRBuilderWrapper::CreateAtomicRMW);
     Nan::SetPrototypeMethod(functionTemplate, "createBitCast", IRBuilderWrapper::ConvertOperation<&llvm::IRBuilder<>::CreateBitCast>);
     Nan::SetPrototypeMethod(functionTemplate, "createBr", IRBuilderWrapper::CreateBr);
     Nan::SetPrototypeMethod(functionTemplate, "createCall", IRBuilderWrapper::CreateCall);
@@ -257,6 +258,26 @@ NAN_METHOD(IRBuilderWrapper::CreateAlloca) {
     auto* alloc = irBuilder.CreateAlloca(type, value, name);
 
     info.GetReturnValue().Set(AllocaInstWrapper::of(alloc));
+}
+
+NAN_METHOD(IRBuilderWrapper::CreateAtomicRMW) {
+    if (info.Length() < 4 || !info[0]->IsUint32()
+            || !ValueWrapper::isInstance(info[1])
+            || !ValueWrapper::isInstance(info[2])
+            || !info[3]->IsUint32()) {
+        return Nan::ThrowTypeError("createAtomicRMW needs to be called with: op: AtomicRMWInst.BinOp, ptr: Value, value: Value, ordering: AtomicOrdering");
+    }
+
+    auto& irBuilder = IRBuilderWrapper::FromValue(info.This())->getIRBuilder();
+
+    auto op = static_cast<llvm::AtomicRMWInst::BinOp>(Nan::To<uint32_t>(info[0]).FromJust());
+    llvm::Value *ptr = ValueWrapper::FromValue(info[1])->getValue();
+    llvm::Value *value = ValueWrapper::FromValue(info[2])->getValue();
+    auto ordering = static_cast<llvm::AtomicOrdering>(Nan::To<uint32_t>(info[3]).FromJust());
+
+    auto *instruction = irBuilder.CreateAtomicRMW(op, ptr, value, ordering);
+
+    info.GetReturnValue().Set(ValueWrapper::of(instruction));
 }
 
 NAN_METHOD(IRBuilderWrapper::CreateExtractValue) {

--- a/src/ir/ir-builder.h
+++ b/src/ir/ir-builder.h
@@ -37,6 +37,7 @@ private:
     static NAN_METHOD(CreateAlignedStore);
     static NAN_METHOD(CreateAnd);
     static NAN_METHOD(CreateAShr);
+    static NAN_METHOD(CreateAtomicRMW);
     static NAN_METHOD(CreateBitCast);
     static NAN_METHOD(CreateBr);
     static NAN_METHOD(CreateCall);

--- a/src/ir/ir.cc
+++ b/src/ir/ir.cc
@@ -33,10 +33,12 @@
 #include "constant-array.h"
 #include "visibility-types.h"
 #include "attribute.h"
+#include "atomic-rmw-inst.h"
 #include "undef-value.h"
 
 NAN_MODULE_INIT(InitIR) {
     AllocaInstWrapper::Init(target);
+    InitAtomicRMWInst(target);
     ArgumentWrapper::Init(target);
     ArrayTypeWrapper::Init(target);
     IntegerTypeWrapper::Init(target);

--- a/src/support/atomic-ordering.cc
+++ b/src/support/atomic-ordering.cc
@@ -1,0 +1,15 @@
+#include <llvm/Support/AtomicOrdering.h>
+#include "atomic-ordering.h"
+
+NAN_MODULE_INIT(InitAtomicOrdering) {
+    auto atomicOrdering = Nan::New<v8::Object>();
+    Nan::Set(atomicOrdering, Nan::New("NotAtomic").ToLocalChecked(), Nan::New(static_cast<uint32_t>(llvm::AtomicOrdering::NotAtomic)));
+    Nan::Set(atomicOrdering, Nan::New("Unordered").ToLocalChecked(), Nan::New(static_cast<uint32_t>(llvm::AtomicOrdering::Unordered)));
+    Nan::Set(atomicOrdering, Nan::New("Monotonic").ToLocalChecked(), Nan::New(static_cast<uint32_t>(llvm::AtomicOrdering::Monotonic)));
+    Nan::Set(atomicOrdering, Nan::New("Acquire").ToLocalChecked(), Nan::New(static_cast<uint32_t>(llvm::AtomicOrdering::Acquire)));
+    Nan::Set(atomicOrdering, Nan::New("Release").ToLocalChecked(), Nan::New(static_cast<uint32_t>(llvm::AtomicOrdering::Release)));
+    Nan::Set(atomicOrdering, Nan::New("AcquireRelease").ToLocalChecked(), Nan::New(static_cast<uint32_t>(llvm::AtomicOrdering::AcquireRelease)));
+    Nan::Set(atomicOrdering, Nan::New("SequentiallyConsistent").ToLocalChecked(), Nan::New(static_cast<uint32_t>(llvm::AtomicOrdering::SequentiallyConsistent)));
+
+    Nan::Set(target, Nan::New("AtomicOrdering").ToLocalChecked(), atomicOrdering);
+}

--- a/src/support/atomic-ordering.h
+++ b/src/support/atomic-ordering.h
@@ -1,0 +1,8 @@
+#ifndef LLVM_NODE_ATOMIC_ORDERING_H
+#define LLVM_NODE_ATOMIC_ORDERING_H
+
+#include <nan.h>
+
+NAN_MODULE_INIT(InitAtomicOrdering);
+
+#endif //LLVM_NODE_ATOMIC_ORDERING_H

--- a/src/support/support.cc
+++ b/src/support/support.cc
@@ -1,5 +1,6 @@
 #include <llvm/Support/TargetSelect.h>
 #include "support.h"
+#include "atomic-ordering.h"
 
 NAN_METHOD(InitializeAllTargetInfos) {
     llvm::InitializeAllTargetInfos();
@@ -22,31 +23,32 @@ NAN_METHOD(InitializeAllAsmPrinters) {
 }
 
 NAN_MODULE_INIT(InitSupport) {
-    Nan::Set(target, 
+    Nan::Set(target,
         Nan::New<v8::String>("initializeAllTargetInfos").ToLocalChecked(),
         Nan::GetFunction(Nan::New<v8::FunctionTemplate>(InitializeAllTargetInfos)).ToLocalChecked()
     );
 
-    Nan::Set(target, 
+    Nan::Set(target,
         Nan::New<v8::String>("initializeAllTargets").ToLocalChecked(),
         Nan::GetFunction(Nan::New<v8::FunctionTemplate>(InitializeAllTargets)).ToLocalChecked()
     );
 
-     Nan::Set(target, 
+     Nan::Set(target,
         Nan::New<v8::String>("initializeAllTargetMCs").ToLocalChecked(),
         Nan::GetFunction(Nan::New<v8::FunctionTemplate>(InitializeAllTargetMCs)).ToLocalChecked()
     );
 
-     Nan::Set(target, 
+     Nan::Set(target,
         Nan::New<v8::String>("initializeAllAsmParsers").ToLocalChecked(),
         Nan::GetFunction(Nan::New<v8::FunctionTemplate>(InitializeAllAsmParsers)).ToLocalChecked()
     );
 
-     Nan::Set(target, 
+     Nan::Set(target,
         Nan::New<v8::String>("initializeAllAsmPrinters").ToLocalChecked(),
         Nan::GetFunction(Nan::New<v8::FunctionTemplate>(InitializeAllAsmPrinters)).ToLocalChecked()
     );
 
+    InitAtomicOrdering(target);
     TargetRegistryWrapper::Init(target);
     TargetWrapper::Init(target);
 }

--- a/test/ir/ir-builder.spec.ts
+++ b/test/ir/ir-builder.spec.ts
@@ -78,6 +78,29 @@ describe("IRBuilder", () => {
     expect(ashr).toEqual(llvm.ConstantInt.get(context, 2));
   });
 
+  test("create createAtomicRMW returns a value", () => {
+    const { builder, context } = createBuilderWithBlock();
+
+    // let %0: i32 = 3;
+    const value = builder.createAlloca(
+        llvm.Type.getInt32Ty(context)
+    );
+
+    builder.createStore(
+        llvm.ConstantInt.get(context, 3),
+        value
+    );
+
+    const atomicRMW = builder.createAtomicRMW(
+      llvm.AtomicRMWInst.BinOp.Add,
+      value,
+      llvm.ConstantInt.get(context, 1),
+      llvm.AtomicOrdering.AcquireRelease
+    );
+
+    expect(atomicRMW).toBeInstanceOf(llvm.Value);
+  });
+
   test("createBitCast returns a value", () => {
     const { builder, context } = createBuilderWithBlock();
 


### PR DESCRIPTION
This adds the `atomicrmw` command for RMW atomics. To specify which operation a few enums were created. The entire `AtomicRMWInst` wasn't added as a class because only the enum was needed rather than any fields

Signed-off-by: Vihan <vihan+github@vihan.org>