### PR TITLE
Add libclang-X-dev to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
   - wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
   - echo $LLVM_DEB | sudo tee -a /etc/apt/sources.list
   - sudo apt-get update -qq
-  - sudo apt-get install libedit-dev llvm-$LLVM_VERSION llvm-$LLVM_VERSION-dev clang-$LLVM_VERSION llvm-$LLVM_VERSION-tools
+  - sudo apt-get install libedit-dev llvm-$LLVM_VERSION llvm-$LLVM_VERSION-dev clang-$LLVM_VERSION llvm-$LLVM_VERSION-tools libclang-$LLVM_VERSION-dev
   - npm config set cmake_LLVM_DIR $(llvm-config-$LLVM_VERSION --cmakedir)
 deploy:
   provider: npm


### PR DESCRIPTION
The build is failing with the following error

```
CMake Error at /usr/lib/llvm-9/lib/cmake/llvm/LLVMExports.cmake:1273 (message):
  The imported target "SampleAnalyzerPlugin" references the file
     "/usr/lib/llvm-9/lib/SampleAnalyzerPlugin.so"
  but this file does not exist.  Possible reasons include:
  * The file was deleted, renamed, or moved to another location.
  * An install or uninstall procedure did not complete successfully.
  * The installation package was faulty and contained
     "/usr/lib/llvm-9/lib/cmake/llvm/LLVMExports.cmake"
  but not all the files it references.
```

Add libclang-X-dev as dependency that should contain the referenced file