### PR TITLE
Define NOMINMAX to fix compilation on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
 message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
 
 include_directories(${CMAKE_JS_INC} "./node_modules/nan" ${LLVM_INCLUDE_DIRS})
-add_definitions(${LLVM_DEFINITIONS})
+add_definitions(${LLVM_DEFINITIONS} -DNOMINMAX)
 
 file(GLOB SOURCE_FILES 
         "src/*.h"


### PR DESCRIPTION
Without this the `max` macro defined on Windows will cause errors in LLVM headers:

> c:\users\emlai\src\libs\llvm-8.0.0-windows-amd64-msvc15-libcmt-dbg\include\llvm\adt\stlextras.h(1438): warning C4003: not enough arguments for function-like macro invocation 'max' [C:\Users\emlai\src\ts-llvm\node_modules\llvm-node\build\llvm-node.vcxproj]
