### PR TITLE
Fix build on LLVM 10.0.0

### DIFF
--- a/src/ir/alloca-inst.cc
+++ b/src/ir/alloca-inst.cc
@@ -68,7 +68,11 @@ NAN_SETTER(AllocaInstWrapper::setAlignment) {
     }
 
     auto* wrapper = AllocaInstWrapper::FromValue(info.Holder());
+#if LLVM_VERSION_MAJOR < 10
     wrapper->getAllocaInst()->setAlignment(Nan::To<uint32_t>(value).FromJust());
+#else
+    wrapper->getAllocaInst()->setAlignment(llvm::MaybeAlign(Nan::To<uint32_t>(value).FromJust()));
+#endif
 }
 
 NAN_GETTER(AllocaInstWrapper::getArraySize) {

--- a/src/ir/type.cc
+++ b/src/ir/type.cc
@@ -223,7 +223,7 @@ NAN_METHOD(TypeWrapper::getIntNTy)
 NAN_METHOD(TypeWrapper::getPrimitiveSizeInBits)
 {
     auto *type = TypeWrapper::FromValue(info.Holder())->getType();
-    info.GetReturnValue().Set(Nan::New(type->getPrimitiveSizeInBits()));
+    info.GetReturnValue().Set(Nan::New<v8::Uint32>(static_cast<uint32_t>(type->getPrimitiveSizeInBits())));
 }
 
 Nan::Persistent<v8::FunctionTemplate> &TypeWrapper::typeTemplate()


### PR DESCRIPTION
Fixed some breaking changes to the 10.0.0 api.

Probably cannot be merged without breaking earlier versions but you might want to use this for LLVM 10 compatibility.